### PR TITLE
Fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ COPY --from=0 /work/bigquery-emulator /bin/bigquery-emulator
 
 WORKDIR /work
 
-CMD ["/bin/bigquery-emulator"]
+ENTRYPOINT ["/bin/bigquery-emulator"]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ $ ./bigquery-emulator --project=test
 [bigquery-emulator] listening at 0.0.0.0:9050
 ```
 
+If you want to use docker image to start emulator, specify like the following.
+
+```console
+$ docker run -it ghcr.io/goccy/bigquery-emulator:latest --project=test
+```
+
 ## How to use from bq client
 
 ### 1. Start the standalone server


### PR DESCRIPTION
The bigquery-emulator requires a project option to start, so we should always override CMD.
Therefore, we make use of ENTRYPOINT so that only options can be specified.