### PR TITLE
Add job and table metadata

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -9,6 +9,7 @@ type (
 		Rows         []*TableRow              `json:"rows"`
 		TotalRows    uint64                   `json:"totalRows,string"`
 		JobComplete  bool                     `json:"jobComplete"`
+		TotalBytes   uint64                   `json:"-"`
 	}
 
 	QueryResponse struct {
@@ -17,6 +18,7 @@ type (
 		Rows         []*TableRow              `json:"rows"`
 		TotalRows    uint64                   `json:"totalRows,string"`
 		JobComplete  bool                     `json:"jobComplete"`
+		TotalBytes   int64                    `json:"-"`
 	}
 
 	TableDataList struct {
@@ -31,6 +33,7 @@ type (
 	// Redefines the TableCell type to return null explicitly
 	// because TableCell for bigqueryv2 is omitted if V is nil,
 	TableCell struct {
-		V interface{} `json:"v"`
+		V     interface{} `json:"v"`
+		Bytes int64       `json:"-"`
 	}
 )

--- a/server/loader.go
+++ b/server/loader.go
@@ -28,6 +28,7 @@ func (s *Server) addProject(ctx context.Context, project *types.Project) error {
 	defer tx.RollbackIfNotCommitted()
 	for _, dataset := range project.Datasets {
 		for _, table := range dataset.Tables {
+			table.SetupMetadata(project.ID, dataset.ID)
 			if err := s.addTableData(ctx, tx, project, dataset, table); err != nil {
 				return err
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -229,5 +229,7 @@ func (s *Server) Stop(ctx context.Context) error {
 }
 
 func (s *Server) TestServer() *httptest.Server {
-	return httptest.NewServer(s.Handler)
+	server := httptest.NewServer(s.Handler)
+	s.httpServer = server.Config
+	return server
 }


### PR DESCRIPTION
fix #41 

Add more metadata for job and table resource .
Currently, `totalBytesProcessed` is a virtual number calculated from the record size.
