### PR TITLE
Fix timestamp format for python client

### DIFF
--- a/_examples/python/data.yaml
+++ b/_examples/python/data.yaml
@@ -9,8 +9,12 @@ projects:
               type: INTEGER
             - name: name
               type: STRING
+            - name: createdAt
+              type: TIMESTAMP
           data:
             - id: 1
               name: alice
+              createdAt: "2022-10-21T00:00:00"
             - id: 2
               name: bob
+              createdAt: "2022-10-21T00:00:00"

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,6 +1,11 @@
 package types
 
-import bigqueryv2 "google.golang.org/api/bigquery/v2"
+import (
+	"fmt"
+	"strconv"
+
+	bigqueryv2 "google.golang.org/api/bigquery/v2"
+)
 
 type (
 	GetQueryResultsResponse struct {
@@ -37,3 +42,27 @@ type (
 		Bytes int64       `json:"-"`
 	}
 )
+
+func Format(schema *bigqueryv2.TableSchema, rows []*TableRow, useInt64Timestamp bool) []*TableRow {
+	if !useInt64Timestamp {
+		return rows
+	}
+	formattedRows := make([]*TableRow, 0, len(rows))
+	for _, row := range rows {
+		cells := make([]*TableCell, 0, len(row.F))
+		for colIdx, cell := range row.F {
+			if schema.Fields[colIdx].Type == "TIMESTAMP" {
+				f64, _ := strconv.ParseFloat(cell.V.(string), 64)
+				cells = append(cells, &TableCell{
+					V: fmt.Sprint(int64(f64)),
+				})
+			} else {
+				cells = append(cells, cell)
+			}
+		}
+		formattedRows = append(formattedRows, &TableRow{
+			F: cells,
+		})
+	}
+	return formattedRows
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -2,8 +2,9 @@ package types
 
 import (
 	"fmt"
-	"strconv"
+	"time"
 
+	"github.com/goccy/go-zetasqlite"
 	bigqueryv2 "google.golang.org/api/bigquery/v2"
 )
 
@@ -52,9 +53,10 @@ func Format(schema *bigqueryv2.TableSchema, rows []*TableRow, useInt64Timestamp 
 		cells := make([]*TableCell, 0, len(row.F))
 		for colIdx, cell := range row.F {
 			if schema.Fields[colIdx].Type == "TIMESTAMP" {
-				f64, _ := strconv.ParseFloat(cell.V.(string), 64)
+				t, _ := zetasqlite.TimeFromTimestampValue(cell.V.(string))
+				microsec := t.UnixNano() / int64(time.Microsecond)
 				cells = append(cells, &TableCell{
-					V: fmt.Sprint(int64(f64)),
+					V: fmt.Sprint(microsec),
 				})
 			} else {
 				cells = append(cells, cell)


### PR DESCRIPTION
ref https://github.com/goccy/bigquery-emulator/issues/32#issuecomment-1285169761

Python client library uses `useInt64Timestamp` option ( https://cloud.google.com/bigquery/docs/reference/rest/v2/DataFormatOptions ) to request query contains `TIMESTAMP` column.
So, emulator handle this option and need to format that column value before returns response .
