### PR TITLE
Fix caller position for errorResponse

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -25,7 +25,7 @@ import (
 )
 
 func errorResponse(ctx context.Context, w http.ResponseWriter, e *ServerError) {
-	logger.Logger(ctx).Error(string(e.Reason), zap.Error(e))
+	logger.Logger(ctx).WithOptions(zap.AddCallerSkip(1)).Error(string(e.Reason), zap.Error(e))
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(e.Status)
 	w.Write(e.Response())
@@ -85,8 +85,7 @@ func (h *discoveryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	encodeResponse(ctx, w, discoveryAPIResponse)
 }
 
-type uploadHandler struct {
-}
+type uploadHandler struct{}
 
 type UploadJobConfigurationLoad struct {
 	AllowJaggedRows                    bool                                   `json:"allowJaggedRows,omitempty"`
@@ -1208,7 +1207,6 @@ func (h *modelsListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	encodeResponse(ctx, w, res)
-
 }
 
 type modelsListRequest struct {


### PR DESCRIPTION
Hi @goccy. Thank you for the nice OSS.

I debug some features in this emulator. But, it is difficult to find where the error occurs. So, I fixed caller position with [zap.AddCallerSkip](https://pkg.go.dev/go.uber.org/zap#AddCallerSkip).

### Before:

`server/handler.go:28` show the line zap.Logger called.

```
2022-10-23T11:00:49.663+0900    ERROR   server/handler.go:28    invalid {"error": "invalid: failed to decode job: invalid character '-' in numeric literal"}
```

### After:

`server/handler.go:182` show the line the handler returns the error.

```
2022-10-23T11:01:26.637+0900    ERROR   server/handler.go:182   invalid {"error": "invalid: failed to decode job: invalid character '-' in numeric literal"}
```
