### PR TITLE
Return 409 error when table duplicates

### DIFF
--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/goccy/bigquery-emulator/internal/connection"
 	"github.com/goccy/bigquery-emulator/internal/logger"
+	"github.com/goccy/bigquery-emulator/internal/metadata"
 	internaltypes "github.com/goccy/bigquery-emulator/internal/types"
 	"github.com/goccy/bigquery-emulator/types"
 )
@@ -71,6 +72,9 @@ func (r *Repository) CreateTable(ctx context.Context, tx *connection.Tx, table *
 	}
 	query := fmt.Sprintf("CREATE TABLE `%s` (%s)", ref.TableId, strings.Join(fields, ","))
 	if _, err := tx.Tx().ExecContext(ctx, query); err != nil {
+		if strings.HasSuffix(err.Error(), "already exists") {
+			return fmt.Errorf("table %s: %w", ref.TableId, metadata.ErrDuplicatedTable)
+		}
 		return fmt.Errorf("failed to create table %s: %w", query, err)
 	}
 	return nil

--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/goccy/bigquery-emulator/internal/connection"
 	"github.com/goccy/bigquery-emulator/internal/logger"
-	"github.com/goccy/bigquery-emulator/internal/metadata"
 	internaltypes "github.com/goccy/bigquery-emulator/internal/types"
 	"github.com/goccy/bigquery-emulator/types"
 )
@@ -72,9 +71,6 @@ func (r *Repository) CreateTable(ctx context.Context, tx *connection.Tx, table *
 	}
 	query := fmt.Sprintf("CREATE TABLE `%s` (%s)", ref.TableId, strings.Join(fields, ","))
 	if _, err := tx.Tx().ExecContext(ctx, query); err != nil {
-		if strings.HasSuffix(err.Error(), "already exists") {
-			return fmt.Errorf("table %s: %w", ref.TableId, metadata.ErrDuplicatedTable)
-		}
 		return fmt.Errorf("failed to create table %s: %w", query, err)
 	}
 	return nil

--- a/internal/metadata/dataset.go
+++ b/internal/metadata/dataset.go
@@ -132,10 +132,6 @@ func (d *Dataset) DeleteModel(ctx context.Context, tx *sql.Tx, id string) error 
 
 func (d *Dataset) AddTable(ctx context.Context, tx *sql.Tx, table *Table) error {
 	d.mu.Lock()
-	if _, exists := d.tableMap[table.ID]; exists {
-		d.mu.Unlock()
-		return fmt.Errorf("table %s is already created", table.ID)
-	}
 	if err := table.Insert(ctx, tx); err != nil {
 		d.mu.Unlock()
 		return err
@@ -148,6 +144,13 @@ func (d *Dataset) AddTable(ctx context.Context, tx *sql.Tx, table *Table) error 
 		return err
 	}
 	return nil
+}
+
+func (d *Dataset) HaveTable(tableID string) bool {
+	d.mu.Lock()
+	_, exists := d.tableMap[tableID]
+	d.mu.Unlock()
+	return exists
 }
 
 func (d *Dataset) Table(id string) *Table {

--- a/server/handler.go
+++ b/server/handler.go
@@ -2041,14 +2041,6 @@ func (h *tablesInsertHandler) Handle(ctx context.Context, r *tablesInsertRequest
 		return nil, errInternalError(err.Error())
 	}
 	defer tx.RollbackIfNotCommitted()
-	if r.table.Schema != nil {
-		if err := r.server.contentRepo.CreateTable(ctx, tx, r.table); err != nil {
-			if errors.Is(err, metadata.ErrDuplicatedTable) {
-				return nil, errDuplicate(err.Error())
-			}
-			return nil, errInternalError(err.Error())
-		}
-	}
 	if err := r.dataset.AddTable(
 		ctx,
 		tx.Tx(),
@@ -2064,6 +2056,11 @@ func (h *tablesInsertHandler) Handle(ctx context.Context, r *tablesInsertRequest
 			return nil, errDuplicate(err.Error())
 		}
 		return nil, errInternalError(err.Error())
+	}
+	if r.table.Schema != nil {
+		if err := r.server.contentRepo.CreateTable(ctx, tx, r.table); err != nil {
+			return nil, errInternalError(err.Error())
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, errInternalError(fmt.Errorf("failed to commit table: %w", err).Error())

--- a/server/handler.go
+++ b/server/handler.go
@@ -2043,6 +2043,9 @@ func (h *tablesInsertHandler) Handle(ctx context.Context, r *tablesInsertRequest
 	defer tx.RollbackIfNotCommitted()
 	if r.table.Schema != nil {
 		if err := r.server.contentRepo.CreateTable(ctx, tx, r.table); err != nil {
+			if errors.Is(err, metadata.ErrDuplicatedTable) {
+				return nil, errDuplicate(err.Error())
+			}
 			return nil, errInternalError(err.Error())
 		}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -517,7 +517,7 @@ func TestDuplicateTable(t *testing.T) {
 	const (
 		projectName = "test"
 		datasetName = "dataset1"
-		table1Name  = "table1"
+		tableName   = "table_a"
 	)
 
 	ctx := context.Background()
@@ -547,12 +547,12 @@ func TestDuplicateTable(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer client.Close()
-	table1 := client.Dataset(datasetName).Table(table1Name)
-	if err := table1.Create(ctx, nil); err != nil {
+	table := client.Dataset(datasetName).Table(tableName)
+	if err := table.Create(ctx, nil); err != nil {
 		t.Fatalf("%+v", err)
 	}
 
-	if err := table1.Create(ctx, nil); err != nil {
+	if err := table.Create(ctx, nil); err != nil {
 		ge := err.(*googleapi.Error)
 		if ge.Code != 409 {
 			t.Fatalf("%+v", ge)
@@ -566,7 +566,7 @@ func TestDuplicateTableWithSchema(t *testing.T) {
 	const (
 		projectName = "test"
 		datasetName = "dataset1"
-		table1Name  = "table1"
+		tableName   = "table_a"
 	)
 
 	ctx := context.Background()
@@ -597,7 +597,7 @@ func TestDuplicateTableWithSchema(t *testing.T) {
 	}
 	defer client.Close()
 
-	table1 := client.Dataset(datasetName).Table(table1Name)
+	table := client.Dataset(datasetName).Table(tableName)
 
 	schema := bigquery.Schema{
 		{Name: "id", Required: true, Type: bigquery.StringFieldType},
@@ -605,11 +605,11 @@ func TestDuplicateTableWithSchema(t *testing.T) {
 		{Name: "timestamp", Required: false, Type: bigquery.TimestampFieldType},
 	}
 	metaData := &bigquery.TableMetadata{Schema: schema}
-	if err := table1.Create(ctx, metaData); err != nil {
+	if err := table.Create(ctx, metaData); err != nil {
 		t.Fatalf("%+v", err)
 	}
 
-	if err := table1.Create(ctx, metaData); err != nil {
+	if err := table.Create(ctx, metaData); err != nil {
 		ge := err.(*googleapi.Error)
 		if ge.Code != 409 {
 			t.Fatalf("%+v", ge)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goccy/bigquery-emulator/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -509,6 +510,55 @@ func TestTable(t *testing.T) {
 		ExpirationTime: time.Now().Add(1 * time.Hour),
 	}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestDuplicateTable(t *testing.T) {
+	const (
+		projectName = "test"
+		datasetName = "dataset1"
+		table1Name  = "table1"
+	)
+
+	ctx := context.Background()
+
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := types.NewProject(projectName, types.NewDataset(datasetName))
+	if err := bqServer.Load(server.StructSource(project)); err != nil {
+		t.Fatal(err)
+	}
+
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Close()
+	}()
+
+	client, err := bigquery.NewClient(
+		ctx,
+		projectName,
+		option.WithEndpoint(testServer.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	table1 := client.Dataset(datasetName).Table(table1Name)
+	if err := table1.Create(ctx, nil); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if err := table1.Create(ctx, nil); err != nil {
+		ge := err.(*googleapi.Error)
+		if ge.Code != 409 {
+			t.Fatalf("%+v", ge)
+		}
+	} else {
+		t.Fatalf(("Threre should be error, when table name duplicates."))
 	}
 }
 


### PR DESCRIPTION
Hi thanks for nice repository!!

About [this API](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/insert) , I found that emulator returns 500 error if specified table name already exists.

Because of this behavior, `Client.create_table(..., exist_ok=True)` in python client doesn't work.

So I changed this behavior to return 409 error as defined [this page](https://cloud.google.com/bigquery/docs/error-messages?hl=ja#errortable).

I checked this feature with following python code.

```python
from google.api_core.client_options import ClientOptions
from google.auth.credentials import AnonymousCredentials
from google.cloud import bigquery

client_options = ClientOptions(api_endpoint="http://0.0.0.0:9050")
client = bigquery.Client(
    "test",
    client_options=client_options,
    credentials=AnonymousCredentials(),
)

dataset_name = "dataset1"
table_name = "test"

client.create_dataset(dataset_name)
table = bigquery.Table(table_ref=f'test.dataset1.{table_name}', schema=[
    bigquery.SchemaField('name', 'STRING', mode='NULLABLE'),
])

client.create_table(table, retry=0, timeout=5.0, exists_ok=True) # go through
client.create_table(table, retry=0, timeout=5.0) # get error
```