### PR TITLE
Added expose 9050, 9060 on Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ COPY --from=0 /work/bigquery-emulator /bin/bigquery-emulator
 
 WORKDIR /work
 
+EXPOSE 9050
+EXPOSE 9060
+
 ENTRYPOINT ["/bin/bigquery-emulator"]


### PR DESCRIPTION
Hi, I have added expose ports in Dockerfile. Because dktest (https://github.com/dhui/dktest) can't find this ports by default. I would be grateful if you accept this PR and rebuild Docker image. 