### PR TITLE
Fix Query DryRun failures should return early with status codes

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -1407,6 +1407,10 @@ func (h *jobsInsertHandler) Handle(ctx context.Context, r *jobsInsertRequest) (*
 		job.Configuration.Query.Query,
 		job.Configuration.Query.QueryParameters,
 	)
+	if jobErr != nil && job.Configuration.DryRun {
+		return nil, jobErr
+	}
+
 	endTime := time.Now()
 	if job.JobReference.JobId == "" {
 		job.JobReference.JobId = randomID() // generate job id


### PR DESCRIPTION
This change brings Query dry-run exceptions (syntax errors, inaccessible tables, etc) closer to BigQuery behavior and adds test coverage.

## Current behavior:
Test script with invalid query syntax, intended to trigger dry run exception:
```python
from google.cloud.bigquery import Client, QueryJobConfig

def callback(callback_job):
    print(f"Callback Job: {callback_job}" )

invalid_query = "SEL"
job = Client().query(invalid_query, job_config=QueryJobConfig(dry_run=True))
job.add_done_callback(callback)

print(f"Query Job: {job}")
```

_When_: Run against **BigQuery** (`BIGQUERY_EMULATOR_HOST` is undefined)
_Then_: BigQuery _correctly_ returns `Syntax error` exception 
```
Traceback (most recent call last):
...
    raise exceptions.from_http_response(response)
google.api_core.exceptions.BadRequest: 400 POST https://bigquery.googleapis.com/bigquery/v2/projects/<redacted>/jobs?prettyPrint=false: Syntax error: Expected end of input but got identifier "SEL" at [1:1]

Location: None
Job ID: 28ee0424-c7ec-4b79-a61b-63e94475fad8
```

_When_: Run against **Emulator** (`BIGQUERY_EMULATOR_HOST=http://localhost:9050`, branch is `main`)
_Then_: Emulator _incorrectly_ returns successful job and triggers callback
```
Callback Job: QueryJob<project=test-project, location=None, id=8bb89ea1-fb35-47f7-badb-a316a3ff8d14>
Query Job: QueryJob<project=test-project, location=None, id=8bb89ea1-fb35-47f7-badb-a316a3ff8d14>
```


## PR behavior:
_When_: Run against **Emulator** (`BIGQUERY_EMULATOR_HOST=http://localhost:9050`, branch is `fix-query-dryrun-errors`)
_Then_: Emulator _correctly_ returns `Syntax error` exception)
```
Traceback (most recent call last):
...
    raise exceptions.from_http_response(response)
google.api_core.exceptions.BadRequest: 400 POST http://localhost:9050/bigquery/v2/projects/<redacted>/jobs?prettyPrint=false: failed to parse statements: failed to parse statement: INVALID_ARGUMENT: Syntax error: Unexpected identifier "SEL" [type.googleapis.com/zetasql.ErrorLocation='\x08\x01\x10\x01']

Location: None
Job ID: b00bcf80-36dc-4bb0-847f-0b63ddb18a03
```
* Note: exception message is not same but that can be improved separately

## Closest equivalent tests for:
- Golang: `cloud.google.com/go/bigquery`: [`query_test.TestQuery()`](https://github.com/googleapis/python-bigquery/blob/main/tests/system/test_query.py#L431-L452) 
- Python: `cloud.google.bigquery`: [`tests/systems/test_query.py.test_dry_run()`](https://github.com/googleapis/python-bigquery/blob/main/tests/system/test_query.py#L431-L452)