### PR TITLE
Add environment variables for project and dataset

### DIFF
--- a/cmd/bigquery-emulator/main.go
+++ b/cmd/bigquery-emulator/main.go
@@ -15,8 +15,8 @@ import (
 )
 
 type option struct {
-	Project      string           `description:"specify the project name" long:"project"`
-	Dataset      string           `description:"specify the dataset name" long:"dataset"`
+	Project      string           `description:"specify the project name" long:"project" env:"BIGQUERY_EMULATOR_PROJECT"`
+	Dataset      string           `description:"specify the dataset name" long:"dataset" env:"BIGQUERY_EMULATOR_DATASET"`
 	HTTPPort     uint16           `description:"specify the http port number. this port used by bigquery api" long:"port" default:"9050"`
 	GRPCPort     uint16           `description:"specify the grpc port number. this port used by bigquery storage api" long:"grpc-port" default:"9060"`
 	LogLevel     server.LogLevel  `description:"specify the log level (debug/info/warn/error)" long:"log-level" default:"error"`


### PR DESCRIPTION
I'm trying to use the BQ emulator in a Github workflow. Github, unfortunately, does not allow workflows to set arguments the way `docker run` does. I've tried overriding the entrypoint, but that doesn't work either (it tries to `stat` the entire string including the arguments and decides the entrypoint doesn't exist).

I'd like to add a project/dataset env variable so I can use Github's `env` in the `services` block to set the project/dataset using environment variables, which GH workflows do support.