### PR TITLE
Upgrade to go 1.21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
           - os: ubuntu-latest
             artifact_name: bigquery-emulator
             asset_name: bigquery-emulator-linux-amd64
-            go-version: "1.18"
+            go-version: "1.21"
           - os: macos-latest
             artifact_name: bigquery-emulator
             asset_name: bigquery-emulator-darwin-amd64
-            go-version: "1.18"
+            go-version: "1.21"
 
     steps:
     - name: checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-latest", "macos-latest" ]
-        go-version: [ "1.18" ]
+        go-version: [ "1.21" ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: checkout
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-latest", "macos-latest" ]
-        go-version: [ "1.18" ]
+        go-version: [ "1.21" ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: setup Go ${{ matrix.go-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.3-bullseye
+FROM golang:1.21.3-bullseye
 
 ARG VERSION
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goccy/bigquery-emulator
 
-go 1.18
+go 1.21
 
 require (
 	cloud.google.com/go/bigquery v1.51.0


### PR DESCRIPTION
There are a number of pre-go 1.21 CVEs (see [here](https://security-tracker.debian.org/tracker/source-package/golang-1.18), [here](https://security-tracker.debian.org/tracker/source-package/golang-1.19), [here](https://security-tracker.debian.org/tracker/source-package/golang-1.20)) that can be resolved by upgrading.