### PR TITLE
enable import from GCS emulator without `PublicHost`

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -1062,6 +1062,7 @@ func (h *jobsInsertHandler) importFromGCS(ctx context.Context, r *jobsInsertRequ
 		opts = append(
 			opts,
 			option.WithEndpoint(fmt.Sprintf("%s/storage/v1/", host)),
+			storage.WithJSONReads(),
 			option.WithoutAuthentication(),
 		)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1708,6 +1708,141 @@ func TestImportFromGCS(t *testing.T) {
 	}
 }
 
+func TestImportFromGCSEmulatorWithoutPublicHost(t *testing.T) {
+	const (
+		projectID  = "test"
+		datasetID  = "dataset1"
+		tableID    = "table_a"
+		host       = "127.0.0.1"
+		bucketName = "test-bucket"
+		sourceName = "path/to/data.json"
+	)
+
+	ctx := context.Background()
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := types.NewProject(
+		projectID,
+		types.NewDataset(
+			datasetID,
+			types.NewTable(
+				tableID,
+				[]*types.Column{
+					types.NewColumn("id", types.INT64),
+					types.NewColumn("value", types.INT64),
+				},
+				nil,
+			),
+		),
+	)
+	if err := bqServer.Load(server.StructSource(project)); err != nil {
+		t.Fatal(err)
+	}
+
+	testServer := bqServer.TestServer()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for i := 0; i < 3; i++ {
+		if err := enc.Encode(map[string]interface{}{
+			"id":    i + 1,
+			"value": i + 10,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	storageServer, err := fakestorage.NewServerWithOptions(fakestorage.Options{
+		InitialObjects: []fakestorage.Object{
+			{
+				ObjectAttrs: fakestorage.ObjectAttrs{
+					BucketName: bucketName,
+					Name:       sourceName,
+					Size:       int64(len(buf.Bytes())),
+				},
+				Content: buf.Bytes(),
+			},
+		},
+		Host:   host,
+		Scheme: "http",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	storageServerURL := storageServer.URL()
+	u, err := url.Parse(storageServerURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storageEmulatorHost := fmt.Sprintf("http://%s:%s", host, u.Port())
+	t.Setenv("STORAGE_EMULATOR_HOST", storageEmulatorHost)
+
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+		storageServer.Stop()
+	}()
+
+	client, err := bigquery.NewClient(
+		ctx,
+		projectID,
+		option.WithEndpoint(testServer.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	gcsSourceURL := fmt.Sprintf("gs://%s/%s", bucketName, sourceName)
+	gcsRef := bigquery.NewGCSReference(gcsSourceURL)
+	gcsRef.SourceFormat = bigquery.JSON
+	gcsRef.AutoDetect = true
+	loader := client.Dataset(datasetID).Table(tableID).LoaderFrom(gcsRef)
+	loader.WriteDisposition = bigquery.WriteTruncate
+	job, err := loader.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Err() != nil {
+		t.Fatal(status.Err())
+	}
+
+	query := client.Query(fmt.Sprintf("SELECT * FROM %s.%s", datasetID, tableID))
+	it, err := query.Read(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type row struct {
+		ID    int64
+		Value int64
+	}
+	var rows []*row
+	for {
+		var r row
+		if err := it.Next(&r); err != nil {
+			if err == iterator.Done {
+				break
+			}
+			t.Fatal(err)
+		}
+		rows = append(rows, &r)
+	}
+	if diff := cmp.Diff([]*row{
+		{ID: 1, Value: 10},
+		{ID: 2, Value: 11},
+		{ID: 3, Value: 12},
+	}, rows); diff != "" {
+		t.Errorf("(-want +got):\n%s", diff)
+	}
+}
+
 func TestImportWithWildcardFromGCS(t *testing.T) {
 	const (
 		projectID  = "test"


### PR DESCRIPTION
fixes #209 

# Summary of problem:
There is an issue with the job that imports files from GCS, specifically when using the GCS Emulator. As detailed in issue #209, attempts to import data from the GCS Emulator sometimes does not work.

This happens when `publicHost` is not set in GCS Emulator, or access not using `publicHost` .

We have spent quite some time investigating this issue, and considering there's already [an issue](https://github.com/goccy/bigquery-emulator/issues/209) created with comments on it, we believe there is value in making it work without needing to set a publicHost.

#  cause

The problem arises due to two different URL formats used for accessing objects in the GCS Emulator:

* /storage/v1/b/{bucketName}/o/{objectName}
* /{bucketName}/{objectName}

The second URL pattern is only valid for accesses to publicHost in the GCS Emulator. The Go GCS SDK, when downloading files from GCS (using `client.Bucket(...).Object(...).NewReader()`) , accesses the latter URL format, which requires a valid publicHost and results in errors if it's not set.

The issue can be pinpointed in the code here:
When building the URL for data reading, the method at [google-cloud-go#L788-L793](https://github.com/googleapis/google-cloud-go/blob/2020edff24e3ffe127248cf9a90c67593c303e18/storage/http_client.go#L788-L793) is used. This method does not take the API prefix (`storage/v1`) into account, considering only the host, bucket name, and object path. It is internally used in the NewReader method at [bigquery-emulator#L1087](https://github.com/goccy/bigquery-emulator/blob/b4ea9618905d62c82b2afcd11c1b3d3de23cd8b3/server/handler.go#L1087).

However, in the JSON API this problem does not occur, because even when data reading, it uses the former URL format. ([google-api-go-client#L12441](https://github.com/googleapis/google-api-go-client/blob/main/storage/v1/storage-gen.go#L12441)). 

This issue seems to be specific to the Emulator and not a problem with standard GCS usage, likely due to the ability to access objects directly through URLs without an API Prefix on storage.googleapis.com.

# Changes made in this PR:

I have enabled the option to use the JSON API, ensuring that imports work even when a publicHost is not set for the emulator. Since JSON download API introduced in v1.30.0, I have upgraded `cloud.google.com/go/storage` version.

This might be more a problem with the Go GCS SDK than with the BigQuery Emulator. So, if this fix isn't right, please let me know. If that's the case, I'm thinking of making another PR to add guidelines in the README about setting a publicHost for the GCS Emulator.

Thank you for maintaining such a great product.