### PR TITLE
Added issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,32 @@
+name: Bug Report
+description: Report a bug
+labels: bug
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide as much info as possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How can we reproduce it (as minimally and precisely as possible)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else we need to know?
+

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,0 +1,12 @@
+name: Enhancement Tracking Issue
+description: Provide supporting details for a feature in development
+labels: enhancement
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+      description: |
+        Please describe the feature you would like added. If it is a functionality that exists in BigQuery but not in our project, provide a link that illustrates this specific feature in BigQuery
+    validations:
+      required: true


### PR DESCRIPTION
This Pull Request introduces new issue templates for both bug reports and feature requests.
Inspired by the templates used in the Kubernetes repository, these templates are designed in a form format with specified required fields, ensuring comprehensive and structured submissions.

To create a new issue, choose one of the templates, or you can create a blank issue through the "open a blank issue" link 
![image](https://github.com/goccy/bigquery-emulator/assets/1212611/a38d9221-7165-4036-99ba-3423432e6053)

The form looks like this:
![image](https://github.com/goccy/bigquery-emulator/assets/1212611/c1956a79-0168-421d-a645-6eab0e5e401d)
