### PR TITLE
[Queries] Respect `maxResults` parameter when fetching query results

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -14,7 +14,7 @@ type (
 	GetQueryResultsResponse struct {
 		JobReference *bigqueryv2.JobReference `json:"jobReference"`
 		Schema       *bigqueryv2.TableSchema  `json:"schema"`
-		Rows         []*TableRow              `json:"rows"`
+		Rows         []*TableRow              `json:"rows,omitempty"`
 		TotalRows    uint64                   `json:"totalRows,string"`
 		JobComplete  bool                     `json:"jobComplete"`
 		TotalBytes   uint64                   `json:"-"`


### PR DESCRIPTION
Found while writing the Python client regression test for https://github.com/goccy/go-zetasqlite/issues/132.

Closes https://github.com/goccy/bigquery-emulator/issues/262