### PR TITLE
Increase request timeout to avoid `failed to add job: job already created` errors

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -212,7 +212,7 @@ func (s *Server) Serve(ctx context.Context, httpAddr, grpcAddr string) error {
 	httpServer := &http.Server{
 		Handler:      s.Handler,
 		Addr:         httpAddr,
-		WriteTimeout: 15 * time.Second,
+		WriteTimeout: 5 * time.Minute,
 		ReadTimeout:  15 * time.Second,
 	}
 	s.httpServer = httpServer


### PR DESCRIPTION
In our use of the emulator we've encountered complex queries that take longer than 15 seconds to execute. The HTTP server's current configuration will close the connection after a 15 second timeout.

This causes the Python client to retry the request, using the same job id, resulting in the error as noted in #213 

Closes #213