### PR TITLE
fix: data is not appended with committed streams

### DIFF
--- a/server/storage_handler.go
+++ b/server/storage_handler.go
@@ -517,6 +517,10 @@ func (s *storageWriteServer) appendRows(req *storagepb.AppendRowsRequest, msgDes
 			s.sendErrorMessage(stream, streamName, err)
 			return err
 		}
+		if err := tx.Commit(); err != nil {
+			s.sendErrorMessage(stream, streamName, err)
+			return err
+		}
 	} else {
 		status.rows = append(status.rows, data...)
 	}


### PR DESCRIPTION
With the Big Query Storage API, when using a committed stream, I had the same issue as [https://github.com/goccy/bigquery-emulator/issues/247](https://github.com/goccy/bigquery-emulator/issues/247). Looking at the code, it seems that no commit was done to the transaction