### PR TITLE
fix: prevent database rebuild when server starting

### DIFF
--- a/server/source.go
+++ b/server/source.go
@@ -32,12 +32,12 @@ func YAMLSource(path string) Source {
 		if err := dec.Decode(&v); err != nil {
 			return errors.New(yaml.FormatError(err, false, true))
 		}
-		return s.addProjects(context.Background(), v.Projects)
+		return s.addProjects(context.Background(), v.Projects, true)
 	}
 }
 
 func StructSource(projects ...*types.Project) Source {
 	return func(s *Server) error {
-		return s.addProjects(context.Background(), projects)
+		return s.addProjects(context.Background(), projects, false)
 	}
 }


### PR DESCRIPTION
While using the emulator, we encounter the same error as https://github.com/goccy/bigquery-emulator/issues/207.

After looking a bit at the code, I found that when the server is starting, we try to reinsert all data, that are already in the database.

The proposal here is to rebuild the project only when the `--data-from-yaml` is provided. 
So if we found a project, and we are just loading from the database, we stop here, but if we load with the option it removes the project and its jobs and dataset, and rebuild it from scratch.

I don't know all cases, so it might break some edge case, maybe it could be an option to the command.

Let me know if some changes are required. And thanks a lot for the project 🙏 