### PR TITLE
migrate go-genproto to google-cloud-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	go.uber.org/zap v1.21.0
 	golang.org/x/sync v0.3.0
 	google.golang.org/api v0.126.0
-	google.golang.org/genproto v0.0.0-20230822172742-b8732ec3820d
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0
@@ -86,5 +85,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20230822172742-b8732ec3820d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230822172742-b8732ec3820d // indirect
 )

--- a/server/storage_handler.go
+++ b/server/storage_handler.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	storagepb "cloud.google.com/go/bigquery/storage/apiv1/storagepb"
 	"github.com/apache/arrow/go/v10/arrow"
 	"github.com/apache/arrow/go/v10/arrow/array"
 	"github.com/apache/arrow/go/v10/arrow/ipc"
@@ -16,7 +17,6 @@ import (
 	"github.com/goccy/go-json"
 	goavro "github.com/linkedin/goavro/v2"
 	bigqueryv2 "google.golang.org/api/bigquery/v2"
-	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/server/storage_test.go
+++ b/server/storage_test.go
@@ -14,6 +14,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	bqStorage "cloud.google.com/go/bigquery/storage/apiv1"
+	storagepb "cloud.google.com/go/bigquery/storage/apiv1/storagepb"
 	"cloud.google.com/go/bigquery/storage/managedwriter"
 	"cloud.google.com/go/bigquery/storage/managedwriter/adapt"
 	"github.com/GoogleCloudPlatform/golang-samples/bigquery/snippets/managedwriter/exampleproto"
@@ -26,7 +27,6 @@ import (
 	goavro "github.com/linkedin/goavro/v2"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/types/storagepb.go
+++ b/types/storagepb.go
@@ -1,8 +1,8 @@
 package types
 
 import (
+	storagepb "cloud.google.com/go/bigquery/storage/apiv1/storagepb"
 	bigqueryv2 "google.golang.org/api/bigquery/v2"
-	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 )
 
 func TableToProto(t *bigqueryv2.Table) *storagepb.TableSchema {


### PR DESCRIPTION
Since `go-genproto` package is deprecated, replace them by `google-cloud-go` package.

ref: https://github.com/googleapis/google-cloud-go/blob/main/migration.md