### PR TITLE
Build a multi-arch Docker image. Intended to close #215

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
 env:
   REGISTRY: ghcr.io
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/metadata-action@v3
+      - uses: docker/metadata-action@v5
         id: meta
         with:
           images: ${{ env.REGISTRY }}/paul-snively/bigquery-emulator
@@ -23,9 +23,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       - name: setup docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: cache for linux
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         if: runner.os == 'Linux'
         with:
           path: |
@@ -34,12 +34,12 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         with:
           context: .
           push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: docker/metadata-action@v3
         id: meta
         with:
-          images: ${{ env.REGISTRY }}/goccy/bigquery-emulator
+          images: ${{ env.REGISTRY }}/paul-snively/bigquery-emulator
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV CGO_ENABLED=1
 RUN xx-go build -o bigquery-emulator \
   ./cmd/bigquery-emulator && xx-verify bigquery-emulator
 
-FROM debian:bullseye AS emulator
+FROM debian:bookworm AS emulator
 
 COPY --from=1 /work/bigquery-emulator /bin/bigquery-emulator
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
-FROM ghcr.io/goccy/go-zetasql:latest
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+
+FROM --platform=$BUILDPLATFORM ghcr.io/goccy/go-zetasql:latest
+
+RUN apt-get update && apt-get upgrade -y
+
+COPY --from=xx / /
+
+ARG TARGETPLATFORM
+
+# There's a slightly weird combo of stuff that needs to be installed for the $BUILDPLATFORM
+# and for the cross-toolchain, at least for this CGO-enabled target.
+RUN apt-get install -y gcc-multilib g++-multilib
+RUN xx-apt install -y musl-dev gcc libstdc++-12-dev
 
 ARG VERSION
 
@@ -9,11 +22,15 @@ COPY . ./
 RUN go mod edit -replace github.com/goccy/go-zetasql=../go-zetasql
 RUN go mod download
 
-RUN make emulator/build
+# Replace `RUN make emulator/build` with a bog-standard xx-go invocation, so it manages
+# compiler, linker, options, everything.
+ENV CGO_ENABLED=1
+RUN xx-go build -o bigquery-emulator \
+  ./cmd/bigquery-emulator && xx-verify bigquery-emulator
 
 FROM debian:bullseye AS emulator
 
-COPY --from=0 /work/bigquery-emulator /bin/bigquery-emulator
+COPY --from=1 /work/bigquery-emulator /bin/bigquery-emulator
 
 WORKDIR /work
 

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ emulator/build:
 		./cmd/bigquery-emulator
 
 docker/build:
-	docker buildx build --push --platform linux/arm64/v8,linux/amd64 -t bigquery-emulator . --build-arg VERSION=${VERSION}
+	docker buildx build --platform linux/arm64/v8,linux/amd64 -t bigquery-emulator . --build-arg VERSION=${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ emulator/build:
 		./cmd/bigquery-emulator
 
 docker/build:
-	docker build -t bigquery-emulator . --build-arg VERSION=${VERSION}
+	docker buildx build --push --platform linux/arm64/v8,linux/amd64 -t bigquery-emulator . --build-arg VERSION=${VERSION}


### PR DESCRIPTION
This pull request revises the `Dockerfile` to use the [xx Docker cross-compilation helpers](https://github.com/tonistiigi/xx) and the `Makefile` to use Docker's `buildx` extension to build a multi-arch image.