### PR TITLE
Attempted to add support for camel case fields via storage api.

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -464,15 +464,23 @@ func NewTable(id string, columns []*Column, data Data) *Table {
 func NewTableWithSchema(t *bigqueryv2.Table, data Data) (*Table, error) {
 	columns := make([]*Column, 0, len(t.Schema.Fields))
 	nameToFieldMap := map[string]*bigqueryv2.TableFieldSchema{}
+	nameToFieldMapLowerCase := map[string]*bigqueryv2.TableFieldSchema{}
 	for _, field := range t.Schema.Fields {
 		nameToFieldMap[field.Name] = field
+		nameToFieldMapLowerCase[strings.ToLower(field.Name)] = field
 		columns = append(columns, NewColumnWithSchema(field))
 	}
 	newData := Data{}
 	for _, row := range data {
 		rowData := map[string]interface{}{}
 		for k, v := range row {
-			field, exists := nameToFieldMap[k]
+			var field *bigqueryv2.TableFieldSchema
+			var exists bool
+
+			if field, exists = nameToFieldMap[k]; !exists {
+				field, exists = nameToFieldMapLowerCase[strings.ToLower(k)]
+			}
+
 			if !exists {
 				continue
 			}


### PR DESCRIPTION
The storage API streaming implementation (at least in java: https://github.com/googleapis/java-bigquerystorage/blob/8efb8131ff89b57509b4b122c75f765c62514b1c/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BQTableSchemaToProtoDescriptor.java#L145) maps the fields in the protobuff message to lower case. When a stream request is being processed and the proto buff message is unmarshalled they are in lower case (naturally) but then when the table data is being build those fields that are camelCase in the database are ignored because in the request they are lower case.

Since i cannot evaluate what the eventual outcome of replacing the mapping check with lower case might be i added a back up look up with lowercase fields. According to google cloumn names should be case-insensitive (https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#case_sensitivity)

Please advise if a better solution exists.