### PR TITLE
Allow analyzer to use correct query typings by passing query parameter types to `go-zetasqlite`

### DIFF
--- a/internal/connection/manager.go
+++ b/internal/connection/manager.go
@@ -41,6 +41,8 @@ func (t *Tx) Tx() *sql.Tx {
 	return t.tx
 }
 
+func (t *Tx) Conn() *Conn { return t.conn }
+
 func (t *Tx) RollbackIfNotCommitted() error {
 	if t.committed {
 		return nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2378,6 +2378,61 @@ ORDER BY qty DESC;`)
 	if rowCount != 1 {
 		t.Fatal("failed to get result")
 	}
+
+	query = client.Query("SELECT * FROM `test.test_dataset.test_table` WHERE @parameter IS NULL OR 'target text' = @parameter")
+	query.Parameters = []bigquery.QueryParameter{
+		{
+			Name: "parameter",
+			Value: &bigquery.QueryParameterValue{
+				Type: bigquery.StandardSQLDataType{
+					TypeKind: "STRING",
+				},
+				Value: "test",
+			},
+		},
+	}
+	it, err = query.Read(ctx)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		var row []bigquery.Value
+		if err := it.Next(&row); err != nil {
+			if err != iterator.Done {
+				t.Fatal(err)
+			}
+			break
+		}
+		if len(row) != 3 {
+			t.Fatalf("failed to get row: %v", row)
+		}
+	}
+
+	query = client.Query("SELECT * FROM UNNEST(@states)")
+	query.Parameters = []bigquery.QueryParameter{
+		{
+			Name:  "states",
+			Value: []string{"WA", "VA", "WV", "WY"},
+		},
+	}
+	it, err = query.Read(ctx)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		var row []bigquery.Value
+		if err := it.Next(&row); err != nil {
+			if err != iterator.Done {
+				t.Fatal(err)
+			}
+			break
+		}
+		if len(row) != 1 {
+			t.Fatalf("failed to get row: %v", row)
+		}
+	}
 }
 
 func TestMultipleProject(t *testing.T) {
@@ -2579,5 +2634,4 @@ func TestInformationSchema(t *testing.T) {
 			}
 		}
 	})
-
 }


### PR DESCRIPTION
This depends on goccy/go-zetasqlite#213

Closes #312
Closes #234