### PR TITLE
Add handler for new discovery endpoint so that CLI tools like bq work (fix for #290)

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -53,8 +53,9 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 }
 
 const (
-	discoveryAPIEndpoint = "/discovery/v1/apis/bigquery/v2/rest"
-	uploadAPIEndpoint    = "/upload/bigquery/v2/projects/{projectId}/jobs"
+	discoveryAPIEndpoint    = "/discovery/v1/apis/bigquery/v2/rest"
+	newDiscoveryAPIEndpoint = "/$discovery/rest"
+	uploadAPIEndpoint       = "/upload/bigquery/v2/projects/{projectId}/jobs"
 )
 
 //go:embed resources/discovery.json

--- a/server/server.go
+++ b/server/server.go
@@ -79,6 +79,7 @@ func New(storage Storage) (*Server, error) {
 		r.Handle(fmt.Sprintf("/bigquery/v2%s", handler.Path), handler.Handler).Methods(handler.HTTPMethod)
 	}
 	r.Handle(discoveryAPIEndpoint, newDiscoveryHandler(server)).Methods("GET")
+	r.Handle(newDiscoveryAPIEndpoint, newDiscoveryHandler(server)).Methods("GET")
 	r.Handle(uploadAPIEndpoint, &uploadHandler{}).Methods("POST")
 	r.Handle(uploadAPIEndpoint, &uploadContentHandler{}).Methods("PUT")
 	r.PathPrefix("/").Handler(&defaultHandler{})


### PR DESCRIPTION
Fixes #290.

How to test:

1. Compile
  ```
  make emulator/build
 ```
2. Run
  ```
  ./bigquery-emulator --project test-project
  ```
3. Create and show some dataset through `bq`
  ```sh
  bq --api=http://localhost:9050 --project_id=test-project mk new_dataset
  bq --api=http://localhost:9050 --project_id=test-project show new_dataset
  ```


