### PR TITLE
Allow empty slices as parameters

### DIFF
--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -152,9 +152,18 @@ func (r *Repository) Query(ctx context.Context, tx *connection.Tx, projectID, da
 
 	values := []interface{}{}
 	for _, param := range params {
-		value, err := r.queryParameterValueToGoValue(param.ParameterValue)
-		if err != nil {
-			return nil, err
+		var value interface{}
+		switch {
+		case param.ParameterType.Type == "ARRAY" && len(param.ParameterValue.ArrayValues) == 0:
+			value = []interface{}{}
+		case param.ParameterType.Type == "STRUCT" && len(param.ParameterValue.StructValues) == 0:
+			value = map[string]interface{}{}
+		default:
+			var err error
+			value, err = r.queryParameterValueToGoValue(param.ParameterValue)
+			if err != nil {
+				return nil, err
+			}
 		}
 		if param.Name != "" {
 			values = append(values, sql.Named(param.Name, value))

--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -156,8 +156,6 @@ func (r *Repository) Query(ctx context.Context, tx *connection.Tx, projectID, da
 		switch {
 		case param.ParameterType.Type == "ARRAY" && len(param.ParameterValue.ArrayValues) == 0:
 			value = []interface{}{}
-		case param.ParameterType.Type == "STRUCT" && len(param.ParameterValue.StructValues) == 0:
-			value = map[string]interface{}{}
 		default:
 			var err error
 			value, err = r.queryParameterValueToGoValue(param.ParameterValue)

--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -155,7 +155,7 @@ func (r *Repository) Query(ctx context.Context, tx *connection.Tx, projectID, da
 		var value interface{}
 		switch {
 		case param.ParameterType.Type == "ARRAY" && len(param.ParameterValue.ArrayValues) == 0:
-			value = []interface{}{}
+			value = nil
 		default:
 			var err error
 			value, err = r.queryParameterValueToGoValue(param.ParameterValue)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2400,7 +2400,7 @@ SELECT
 FROM test_dataset.test_table
 WHERE
  item IN UNNEST(@items)
- OR item in UNNEST(@empty);`)
+ AND @empty IS NULL;`)
 	query.Parameters = []bigquery.QueryParameter{
 		{
 			Name:  "items",


### PR DESCRIPTION
This fixes a bug where passing empty slices as query parameters would cause a deadlock.