### PR TITLE
Apply command option from environment values

### DIFF
--- a/cmd/bigquery-emulator/main.go
+++ b/cmd/bigquery-emulator/main.go
@@ -15,8 +15,8 @@ import (
 )
 
 type option struct {
-	Project      string           `description:"specify the project name" long:"project"`
-	Dataset      string           `description:"specify the dataset name" long:"dataset"`
+	Project      string           `description:"specify the project name" long:"project" env:"BIGQUERY_EMULATOR_PROJECT"`
+	Dataset      string           `description:"specify the dataset name" long:"dataset" env:"BIGQUERY_EMULATOR_DATASET"`
 	Host         string           `description:"specify the host" long:"host" default:"0.0.0.0"`
 	HTTPPort     uint16           `description:"specify the http port number. this port used by bigquery api" long:"port" default:"9050"`
 	GRPCPort     uint16           `description:"specify the grpc port number. this port used by bigquery storage api" long:"grpc-port" default:"9060"`


### PR DESCRIPTION
# What

- Apply command option from environment values
- If both are specified, `long` takes precedence (this depends on the behavior of `jessevdk/go-flags` and may be changed by this libs update)

# Why

- When we use `GitHub Actions`, we can't take arguments, so we need to pass the value in an environment variable
