### PR TITLE
Handle default DestinationFormat (default is CSV)

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -1292,6 +1292,9 @@ func (h *jobsInsertHandler) exportToGCSWithObject(ctx context.Context, response 
 		}
 	}()
 	switch extract.DestinationFormat {
+	case "": // default format is CSV
+		extract.DestinationFormat = "CSV"
+		fallthrough
 	case "CSV":
 		if len(response.Rows) == 0 {
 			if _, err := writer.Write(nil); err != nil {


### PR DESCRIPTION
# What

- Handle default DestinationFormat

# Why

> The default value for tables is CSV

via. https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationextract