### PR TITLE
Allow table without schema

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -427,8 +427,10 @@ func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentReque
 		return err
 	}
 	columnToType := map[string]types.Type{}
-	for _, field := range tableContent.Schema.Fields {
-		columnToType[field.Name] = types.Type(field.Type)
+	if tableContent.Schema != nil {
+		for _, field := range tableContent.Schema.Fields {
+			columnToType[field.Name] = types.Type(field.Type)
+		}
 	}
 
 	sourceFormat := load.SourceFormat


### PR DESCRIPTION
# What

- SSIA

# Why

- It's permissible to create a `Table` for which Schema is not defined. (For example, when using `AutoDetect` option).

> schema | object (TableSchema)
> Optional. Describes the schema of this table.

via. https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#resource:-table
via. https://cloud.google.com/bigquery/docs/tables#create_an_empty_table_without_a_schema_definition