### PR TITLE
Implement copying tables

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -1436,6 +1436,11 @@ func (h *jobsInsertHandler) copyTable(ctx context.Context, r *jobsInsertRequest)
 		destinationTable := destinationDataset.Table(dstTable.TableId)
 		destinationTableExists := destinationTable != nil
 		if !destinationTableExists {
+
+			if job.Configuration.Copy.CreateDisposition == "CREATE_NEVER" {
+				return nil, errNotFound(fmt.Sprintf("createDisposition is set to 'CREATE_NEVER' and the table %s does not exist", dstTable.TableId))
+			}
+
 			_, err := createTableMetadata(ctx, tx, r.server, r.project, destinationDataset, tableDef.ToBigqueryV2(r.project.ID, tableRef.DatasetId))
 
 			if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2653,3 +2653,79 @@ func TestInformationSchema(t *testing.T) {
 	})
 
 }
+
+func TestCopyTable(t *testing.T) {
+	t.Run("copy from same dataset", func(t *testing.T) {
+		ctx := context.Background()
+
+		const (
+			projectName = "test"
+			dataset     = "dataset1"
+			srcTable    = "table_a"
+			dstTable    = "table_a_copied"
+		)
+
+		bqServer, err := server.New(server.TempStorage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := bqServer.SetProject(projectName); err != nil {
+			t.Fatal(err)
+		}
+		if err := bqServer.Load(server.YAMLSource(filepath.Join("testdata", "data.yaml"))); err != nil {
+			t.Fatal(err)
+		}
+
+		testServer := bqServer.TestServer()
+		defer func() {
+			testServer.Close()
+			bqServer.Stop(ctx)
+		}()
+
+		client, err := bigquery.NewClient(
+			ctx,
+			projectName,
+			option.WithEndpoint(testServer.URL),
+			option.WithoutAuthentication(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer client.Close()
+
+		src := client.Dataset(dataset).Table(srcTable)
+		dst := client.Dataset(dataset).Table(dstTable)
+		job, err := dst.CopierFrom(src).Run(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		status, err := job.Wait(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = status.Err(); err != nil {
+			t.Fatal(err)
+		}
+		it, err := client.Query("SELECT * FROM test.dataset1.table_a_copied").Read(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var row []bigquery.Value
+		var response [][]bigquery.Value
+		for {
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatal(err)
+			}
+			t.Log("row = ", row)
+			response = append(response, row)
+		}
+		if len(response) != 2 {
+			t.Fatalf("2 rows are expected to be copied, but got %d", len(response))
+		}
+	})
+
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2850,4 +2850,225 @@ func TestCopyTable(t *testing.T) {
 		}
 
 	})
+
+	t.Run("fail if writeDisposition is set to WRITE_EMPTY and the destination table already exists", func(t *testing.T) {
+		ctx := context.Background()
+
+		const (
+			projectName = "test"
+			dataset     = "dataset1"
+			srcTable    = "table_a"
+			dstTable    = "table_c"
+		)
+
+		bqServer, err := server.New(server.TempStorage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := bqServer.SetProject(projectName); err != nil {
+			t.Fatal(err)
+		}
+		if err := bqServer.Load(server.YAMLSource(filepath.Join("testdata", "data.yaml"))); err != nil {
+			t.Fatal(err)
+		}
+
+		testServer := bqServer.TestServer()
+		defer func() {
+			testServer.Close()
+			bqServer.Stop(ctx)
+		}()
+
+		client, err := bigquery.NewClient(
+			ctx,
+			projectName,
+			option.WithEndpoint(testServer.URL),
+			option.WithoutAuthentication(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer client.Close()
+
+		src := client.Dataset(dataset).Table(srcTable)
+		dst := client.Dataset(dataset).Table(dstTable)
+		copier := dst.CopierFrom(src)
+		copier.WriteDisposition = bigquery.WriteEmpty
+
+		_, err = copier.Run(ctx)
+		if err == nil {
+			t.Fatal("The job must be failed")
+		}
+
+		it, err := client.Query("SELECT * FROM test.dataset1.table_c").Read(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var row []bigquery.Value
+		var response [][]bigquery.Value
+		for {
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatal(err)
+			}
+			t.Log("row = ", row)
+			response = append(response, row)
+		}
+		// assert table_c is not modified
+		if len(response) != 3 {
+			t.Fatalf("the table must contain 3 rows, but got %d", len(response))
+		}
+	})
+
+	t.Run("the data is appended to the destination table if writeDisposition is set to WRITE_APPEND", func(t *testing.T) {
+		ctx := context.Background()
+
+		const (
+			projectName = "test"
+			dataset     = "dataset1"
+			srcTable    = "table_a"
+			dstTable    = "table_c"
+		)
+
+		bqServer, err := server.New(server.TempStorage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := bqServer.SetProject(projectName); err != nil {
+			t.Fatal(err)
+		}
+		if err := bqServer.Load(server.YAMLSource(filepath.Join("testdata", "data.yaml"))); err != nil {
+			t.Fatal(err)
+		}
+
+		testServer := bqServer.TestServer()
+		defer func() {
+			testServer.Close()
+			bqServer.Stop(ctx)
+		}()
+
+		client, err := bigquery.NewClient(
+			ctx,
+			projectName,
+			option.WithEndpoint(testServer.URL),
+			option.WithoutAuthentication(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer client.Close()
+
+		src := client.Dataset(dataset).Table(srcTable)
+		dst := client.Dataset(dataset).Table(dstTable)
+		copier := dst.CopierFrom(src)
+		copier.WriteDisposition = bigquery.WriteAppend
+		job, err := copier.Run(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		status, err := job.Wait(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = status.Err(); err != nil {
+			t.Fatal(err)
+		}
+		it, err := client.Query("SELECT * FROM test.dataset1.table_c").Read(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var row []bigquery.Value
+		var response [][]bigquery.Value
+		for {
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatal(err)
+			}
+			t.Log("row = ", row)
+			response = append(response, row)
+		}
+		if len(response) != 5 {
+			t.Fatalf("The table must contain 5 (2+3) rows, but got %d", len(response))
+		}
+	})
+
+	t.Run("overwrite the data and the schema of the destination table if writeDisposition is set to WRITE_TRUNCATE", func(t *testing.T) {
+		ctx := context.Background()
+
+		const (
+			projectName = "test"
+			dataset     = "dataset1"
+			srcTable    = "table_a"
+			dstTable    = "table_b"
+		)
+
+		bqServer, err := server.New(server.TempStorage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := bqServer.SetProject(projectName); err != nil {
+			t.Fatal(err)
+		}
+		if err := bqServer.Load(server.YAMLSource(filepath.Join("testdata", "data.yaml"))); err != nil {
+			t.Fatal(err)
+		}
+
+		testServer := bqServer.TestServer()
+		defer func() {
+			testServer.Close()
+			bqServer.Stop(ctx)
+		}()
+
+		client, err := bigquery.NewClient(
+			ctx,
+			projectName,
+			option.WithEndpoint(testServer.URL),
+			option.WithoutAuthentication(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer client.Close()
+
+		src := client.Dataset(dataset).Table(srcTable)
+		dst := client.Dataset(dataset).Table(dstTable)
+		copier := dst.CopierFrom(src)
+		copier.WriteDisposition = bigquery.WriteTruncate
+		job, err := copier.Run(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		status, err := job.Wait(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = status.Err(); err != nil {
+			t.Fatal(err)
+		}
+		it, err := client.Query("SELECT * FROM test.dataset1.table_b").Read(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var row []bigquery.Value
+		var response [][]bigquery.Value
+		for {
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatal(err)
+			}
+			t.Log("row = ", row)
+			response = append(response, row)
+		}
+		if len(response) != 2 {
+			t.Fatalf("The table must contain 2 rows, but got %d", len(response))
+		}
+	})
 }

--- a/server/testdata/data.yaml
+++ b/server/testdata/data.yaml
@@ -54,3 +54,50 @@ projects:
             - num: 1.2345
               bignum: 1.234567891234
               interval: 1-6 15 0:0:0
+        - id: table_c
+          columns:
+            - name: id
+              type: INTEGER
+              mode: REQUIRED
+            - name: name
+              type: STRING
+              mode: required # lower case
+            - name: structarr
+              type: STRUCT
+              mode: repeated
+              fields:
+                - name: key
+                  type: STRING
+                - name: value
+                  type: JSON
+            - name: birthday
+              type: DATE
+            - name: skillNum
+              type: NUMERIC
+            - name: created_at
+              type: TIMESTAMP
+          data:
+            - id: 3
+              name: carol
+              structarr:
+                - key: profile
+                  value: '{"age": 20}'
+              birthday: "2012-01-01"
+              skillNum: 3
+              created_at: '2022-01-01T12:00:00'
+            - id: 4
+              name: dave
+              structarr:
+                - key: profile
+                  value: '{"age": 25}'
+              birthday: "2007-02-01"
+              skillNum: 5
+              created_at: '2022-01-02T18:00:00'
+            - id: 5
+              name: ellen
+              structarr:
+                - key: profile
+                  value: '{"age": 30}'
+              birthday: "2007-02-01"
+              skillNum: 5
+              created_at: '2022-01-02T18:00:00'


### PR DESCRIPTION
close #353 

This PR implement a feature to copy tables.
https://cloud.google.com/bigquery/docs/managing-tables#copy-table

New test cases on copying tables are added.
All tests have passed.
