### PR TITLE
fix(job): use default storage endpoint to avoid error on get object

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -351,7 +351,7 @@ type uploadContentRequest struct {
 }
 
 func (h *uploadContentHandler) getCandidateName(col string, columnNames []string) string {
-	var (
+	var ( 
 		foundName  string
 		foundCount int
 	)
@@ -1062,7 +1062,6 @@ func (h *jobsInsertHandler) importFromGCS(ctx context.Context, r *jobsInsertRequ
 	if host := os.Getenv(gcsEmulatorHostEnvName); host != "" {
 		opts = append(
 			opts,
-			option.WithEndpoint(fmt.Sprintf("%s/storage/v1/", host)),
 			storage.WithJSONReads(),
 			option.WithoutAuthentication(),
 		)
@@ -1198,7 +1197,6 @@ func (h *jobsInsertHandler) exportToGCS(ctx context.Context, r *jobsInsertReques
 	if host := os.Getenv(gcsEmulatorHostEnvName); host != "" {
 		opts = append(
 			opts,
-			option.WithEndpoint(fmt.Sprintf("%s/storage/v1/", host)),
 			option.WithoutAuthentication(),
 		)
 	}


### PR DESCRIPTION
Hi, following Google storage docs, we don't need to change storage endpoint to use an emulator:

https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest

This problem can be confirmed by issue https://github.com/goccy/bigquery-emulator/issues/404
