### PR TITLE
Support default clauses in create tables

### DIFF
--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -91,7 +91,12 @@ func (r *Repository) CreateTable(ctx context.Context, tx *connection.Tx, table *
 	}
 	fields := make([]string, 0, len(table.Schema.Fields))
 	for _, field := range table.Schema.Fields {
-		fields = append(fields, fmt.Sprintf("`%s` %s", field.Name, r.encodeSchemaField(field)))
+		columnDef := fmt.Sprintf("`%s` %s", field.Name, r.encodeSchemaField(field))
+
+		if field.DefaultValueExpression != "" {
+			columnDef = fmt.Sprintf("%s DEFAULT %s", columnDef, field.DefaultValueExpression)
+		}
+		fields = append(fields, columnDef)
 	}
 	tablePath := r.tablePath(ref.ProjectId, ref.DatasetId, ref.TableId)
 	query := fmt.Sprintf("CREATE TABLE `%s` (%s)", tablePath, strings.Join(fields, ","))

--- a/server/default_values_test.go
+++ b/server/default_values_test.go
@@ -1,0 +1,302 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+func TestDefaultValues(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		projectID = "test"
+		datasetID = "dataset1"
+	)
+
+	bqServer, err := New(TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.SetProject(projectID); err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(
+		StructSource(
+			NewProject(
+				projectID,
+				NewDataset(datasetID),
+			),
+		),
+	); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer testServer.Close()
+
+	client, err := bigquery.NewClient(
+		ctx,
+		projectID,
+		option.WithEndpoint(testServer.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// Test 1: Create table with DEFAULT values using SQL
+	t.Run("CreateTableWithDefaults", func(t *testing.T) {
+		query := `
+		CREATE TABLE dataset1.test_defaults (
+			id INT64 NOT NULL,
+			name STRING DEFAULT 'Unknown',
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
+			status STRING DEFAULT 'active',
+			score FLOAT64 DEFAULT 0.0
+		)`
+
+		job, err := client.Query(query).Run(ctx)
+		if err != nil {
+			t.Fatalf("Failed to create table with defaults: %v", err)
+		}
+		status, err := job.Wait(ctx)
+		if err != nil {
+			t.Fatalf("Failed to wait for job: %v", err)
+		}
+		if err := status.Err(); err != nil {
+			t.Fatalf("Job failed: %v", err)
+		}
+	})
+
+	// Test 2: Insert data without specifying columns with defaults
+	t.Run("InsertWithDefaults", func(t *testing.T) {
+		query := `INSERT INTO dataset1.test_defaults (id) VALUES (1), (2), (3)`
+
+		job, err := client.Query(query).Run(ctx)
+		if err != nil {
+			t.Fatalf("Failed to insert data: %v", err)
+		}
+		status, err := job.Wait(ctx)
+		if err != nil {
+			t.Fatalf("Failed to wait for job: %v", err)
+		}
+		if err := status.Err(); err != nil {
+			t.Fatalf("Insert job failed: %v", err)
+		}
+	})
+
+	// Test 3: Verify DEFAULT values were applied
+	t.Run("VerifyDefaults", func(t *testing.T) {
+		query := `SELECT id, name, status, score FROM dataset1.test_defaults ORDER BY id`
+
+		it, err := client.Query(query).Read(ctx)
+		if err != nil {
+			t.Fatalf("Failed to query table: %v", err)
+		}
+
+		expectedValues := []struct {
+			id     int64
+			name   string
+			status string
+			score  float64
+		}{
+			{1, "Unknown", "active", 0.0},
+			{2, "Unknown", "active", 0.0},
+			{3, "Unknown", "active", 0.0},
+		}
+
+		rowIndex := 0
+		for {
+			var row []bigquery.Value
+			err := it.Next(&row)
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				t.Fatalf("Failed to iterate: %v", err)
+			}
+
+			if rowIndex >= len(expectedValues) {
+				t.Fatalf("Got more rows than expected")
+			}
+
+			expected := expectedValues[rowIndex]
+
+			// Check id
+			if id, ok := row[0].(int64); !ok || id != expected.id {
+				t.Errorf("Row %d: expected id=%d, got %v", rowIndex, expected.id, row[0])
+			}
+
+			// Check name
+			if name, ok := row[1].(string); !ok || name != expected.name {
+				t.Errorf("Row %d: expected name=%s, got %v", rowIndex, expected.name, row[1])
+			}
+
+			// Check status
+			if status, ok := row[2].(string); !ok || status != expected.status {
+				t.Errorf("Row %d: expected status=%s, got %v", rowIndex, expected.status, row[2])
+			}
+
+			// Check score
+			if score, ok := row[3].(float64); !ok || score != expected.score {
+				t.Errorf("Row %d: expected score=%f, got %v", rowIndex, expected.score, row[3])
+			}
+
+			rowIndex++
+		}
+
+		if rowIndex != len(expectedValues) {
+			t.Errorf("Expected %d rows, got %d", len(expectedValues), rowIndex)
+		}
+	})
+
+	// Test 4: Insert with some explicit values
+	t.Run("InsertMixedValues", func(t *testing.T) {
+		query := `INSERT INTO dataset1.test_defaults (id, name, score) VALUES (4, 'Alice', 95.5)`
+
+		job, err := client.Query(query).Run(ctx)
+		if err != nil {
+			t.Fatalf("Failed to insert data: %v", err)
+		}
+		status, err := job.Wait(ctx)
+		if err != nil {
+			t.Fatalf("Failed to wait for job: %v", err)
+		}
+		if err := status.Err(); err != nil {
+			t.Fatalf("Insert job failed: %v", err)
+		}
+
+		// Verify the mixed values
+		verifyQuery := `SELECT id, name, status, score FROM dataset1.test_defaults WHERE id = 4`
+		it, err := client.Query(verifyQuery).Read(ctx)
+		if err != nil {
+			t.Fatalf("Failed to query table: %v", err)
+		}
+
+		var row []bigquery.Value
+		err = it.Next(&row)
+		if err != nil {
+			t.Fatalf("Failed to get row: %v", err)
+		}
+
+		// Check explicitly set values
+		if id, ok := row[0].(int64); !ok || id != 4 {
+			t.Errorf("Expected id=4, got %v", row[0])
+		}
+		if name, ok := row[1].(string); !ok || name != "Alice" {
+			t.Errorf("Expected name=Alice, got %v", row[1])
+		}
+		// Check default value
+		if status, ok := row[2].(string); !ok || status != "active" {
+			t.Errorf("Expected status=active (default), got %v", row[2])
+		}
+		// Check explicitly set value
+		if score, ok := row[3].(float64); !ok || score != 95.5 {
+			t.Errorf("Expected score=95.5, got %v", row[3])
+		}
+	})
+}
+
+func TestDefaultValuesViaAPI(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		projectID = "test"
+		datasetID = "dataset1"
+		tableID   = "test_api_defaults"
+	)
+
+	bqServer, err := New(TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.SetProject(projectID); err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(
+		StructSource(
+			NewProject(
+				projectID,
+				NewDataset(datasetID),
+			),
+		),
+	); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer testServer.Close()
+
+	client, err := bigquery.NewClient(
+		ctx,
+		projectID,
+		option.WithEndpoint(testServer.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// Create table via API with default values
+	t.Run("CreateTableViaAPI", func(t *testing.T) {
+		meta := &bigquery.TableMetadata{
+			Schema: bigquery.Schema{
+				{Name: "id", Type: bigquery.IntegerFieldType, Required: true},
+				{Name: "email", Type: bigquery.StringFieldType, DefaultValueExpression: "'noreply@example.com'"},
+				{Name: "age", Type: bigquery.IntegerFieldType, DefaultValueExpression: "18"},
+				{Name: "active", Type: bigquery.BooleanFieldType, DefaultValueExpression: "true"},
+			},
+		}
+
+		tableRef := client.Dataset(datasetID).Table(tableID)
+		if err := tableRef.Create(ctx, meta); err != nil {
+			t.Fatalf("Failed to create table: %v", err)
+		}
+
+		// Insert data to test defaults
+		query := fmt.Sprintf(`INSERT INTO %s.%s (id) VALUES (100)`, datasetID, tableID)
+		job, err := client.Query(query).Run(ctx)
+		if err != nil {
+			t.Fatalf("Failed to insert data: %v", err)
+		}
+		status, err := job.Wait(ctx)
+		if err != nil {
+			t.Fatalf("Failed to wait for job: %v", err)
+		}
+		if err := status.Err(); err != nil {
+			t.Fatalf("Insert job failed: %v", err)
+		}
+
+		// Verify defaults were applied
+		verifyQuery := fmt.Sprintf(`SELECT id, email, age, active FROM %s.%s WHERE id = 100`, datasetID, tableID)
+		it, err := client.Query(verifyQuery).Read(ctx)
+		if err != nil {
+			t.Fatalf("Failed to query table: %v", err)
+		}
+
+		var row []bigquery.Value
+		err = it.Next(&row)
+		if err != nil {
+			t.Fatalf("Failed to get row: %v", err)
+		}
+
+		// Verify values
+		if id, ok := row[0].(int64); !ok || id != 100 {
+			t.Errorf("Expected id=100, got %v", row[0])
+		}
+		if email, ok := row[1].(string); !ok || email != "noreply@example.com" {
+			t.Errorf("Expected email=noreply@example.com, got %v", row[1])
+		}
+		if age, ok := row[2].(int64); !ok || age != 18 {
+			t.Errorf("Expected age=18, got %v", row[2])
+		}
+		if active, ok := row[3].(bool); !ok || !active {
+			t.Errorf("Expected active=true, got %v", row[3])
+		}
+	})
+}

--- a/types/types.go
+++ b/types/types.go
@@ -86,10 +86,11 @@ const (
 )
 
 type Column struct {
-	Name   string    `yaml:"name" validate:"required"`
-	Type   Type      `yaml:"type" validate:"type"`
-	Mode   Mode      `yaml:"mode" validate:"mode"`
-	Fields []*Column `yaml:"fields"`
+	Name                   string    `yaml:"name" validate:"required"`
+	Type                   Type      `yaml:"type" validate:"type"`
+	Mode                   Mode      `yaml:"mode" validate:"mode"`
+	Fields                 []*Column `yaml:"fields"`
+	DefaultValueExpression string    `yaml:"defaultValueExpression,omitempty"`
 }
 
 func (c *Column) FormatType() string {
@@ -118,9 +119,10 @@ func (c *Column) TableFieldSchema() *bigqueryv2.TableFieldSchema {
 func tableFieldSchemaFromColumn(c *Column) *bigqueryv2.TableFieldSchema {
 	if len(c.Fields) == 0 {
 		return &bigqueryv2.TableFieldSchema{
-			Name: c.Name,
-			Type: string(c.Type.FieldType()),
-			Mode: string(c.Mode),
+			Name:                   c.Name,
+			Type:                   string(c.Type.FieldType()),
+			Mode:                   string(c.Mode),
+			DefaultValueExpression: c.DefaultValueExpression,
 		}
 	}
 	fields := make([]*bigqueryv2.TableFieldSchema, 0, len(c.Fields))
@@ -128,10 +130,11 @@ func tableFieldSchemaFromColumn(c *Column) *bigqueryv2.TableFieldSchema {
 		fields = append(fields, tableFieldSchemaFromColumn(field))
 	}
 	return &bigqueryv2.TableFieldSchema{
-		Name:   c.Name,
-		Type:   string(c.Type.FieldType()),
-		Fields: fields,
-		Mode:   string(c.Mode),
+		Name:                   c.Name,
+		Type:                   string(c.Type.FieldType()),
+		Fields:                 fields,
+		Mode:                   string(c.Mode),
+		DefaultValueExpression: c.DefaultValueExpression,
 	}
 }
 
@@ -519,10 +522,11 @@ func NewColumnWithSchema(s *bigqueryv2.TableFieldSchema) *Column {
 		fields = append(fields, NewColumnWithSchema(field))
 	}
 	return &Column{
-		Name:   s.Name,
-		Type:   Type(s.Type),
-		Mode:   Mode(s.Mode),
-		Fields: fields,
+		Name:                   s.Name,
+		Type:                   Type(s.Type),
+		Mode:                   Mode(s.Mode),
+		Fields:                 fields,
+		DefaultValueExpression: s.DefaultValueExpression,
 	}
 }
 


### PR DESCRIPTION
# Add Support for DEFAULT Clauses in CREATE TABLE Statements

## Summary

This PR adds support for DEFAULT value expressions in BigQuery table schemas, allowing columns to have default values that are automatically applied when inserting data without explicitly specifying values for those columns.

## Motivation

BigQuery supports DEFAULT clauses in table definitions, which is a commonly used feature for:
- Setting default timestamps (e.g., `CURRENT_TIMESTAMP()` for created_at columns)
- Providing fallback values for optional fields (e.g., `'Unknown'` for names, `'active'` for status)
- Initializing numeric fields with default values (e.g., `0.0` for scores)

Previously, the BigQuery emulator did not support this feature, which limited its compatibility with production BigQuery schemas and required workarounds in testing environments.

## Changes

### 1. Core Implementation (`internal/contentdata/repository.go`)
- Modified `CreateTable` function to handle `DefaultValueExpression` from table schemas
- When generating SQL column definitions, the function now checks for default expressions and appends them using the `DEFAULT` clause
- Example: `name STRING` becomes `name STRING DEFAULT 'Unknown'`

### 2. Type System Updates (`types/types.go`)
- Added `DefaultValueExpression` field to the `Column` struct
- Updated `tableFieldSchemaFromColumn` to preserve default expressions when converting to BigQuery API schemas
- Updated `NewColumnWithSchema` to extract default expressions from incoming BigQuery schemas

### 3. Comprehensive Testing (`server/default_values_test.go`)
Added extensive test coverage including:
- Creating tables with various DEFAULT types (STRING, TIMESTAMP, FLOAT64, etc.)
- Inserting rows without specifying columns that have defaults
- Verifying default values are correctly applied
- Testing mixed inserts (some explicit values, some defaults)
- Testing table creation via both SQL DDL and BigQuery API

## Example Usage

### SQL DDL
```sql
CREATE TABLE dataset1.test_defaults (
    id INT64 NOT NULL,
    name STRING DEFAULT 'Unknown',
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
    status STRING DEFAULT 'active',
    score FLOAT64 DEFAULT 0.0
)
```

### BigQuery API
```go
meta := &bigquery.TableMetadata{
    Schema: bigquery.Schema{
        {Name: "id", Type: bigquery.IntegerFieldType, Required: true},
        {Name: "email", Type: bigquery.StringFieldType, DefaultValueExpression: "'noreply@example.com'"},
        {Name: "age", Type: bigquery.IntegerFieldType, DefaultValueExpression: "18"},
        {Name: "active", Type: bigquery.BooleanFieldType, DefaultValueExpression: "true"},
    },
}
```

### Insert Behavior
```sql
-- Only specify id, other columns use defaults
INSERT INTO dataset1.test_defaults (id) VALUES (1), (2), (3)

-- Results in:
-- id | name      | created_at              | status | score
-- 1  | 'Unknown' | 2024-01-01 12:00:00 UTC | 'active' | 0.0
-- 2  | 'Unknown' | 2024-01-01 12:00:01 UTC | 'active' | 0.0
-- 3  | 'Unknown' | 2024-01-01 12:00:02 UTC | 'active' | 0.0
```

## Testing

All tests pass successfully:
- ✅ Table creation with DEFAULT clauses
- ✅ Insert operations respect default values
- ✅ Mixed inserts (explicit + default values)
- ✅ API-based table creation with defaults
- ✅ Various data types (STRING, INT64, FLOAT64, BOOL, TIMESTAMP)

## Compatibility

This implementation maintains backward compatibility:
- Tables without DEFAULT clauses continue to work as before
- Existing table schemas are unaffected
- The feature only activates when `DefaultValueExpression` is explicitly provided

## Limitations & Future Work

1. **Expression Support**: Currently supports literal values and simple functions like `CURRENT_TIMESTAMP()`. Complex expressions may need additional testing.
2. **Schema Updates**: Altering existing tables to add/remove DEFAULT clauses is not yet implemented
3. **Expression Validation**: The emulator currently passes default expressions directly to SQLite. Additional validation could be added to ensure BigQuery compatibility.

## Related Issues

This PR enhances BigQuery emulator compatibility with production BigQuery features, making it more suitable for comprehensive testing scenarios.
