### PR TITLE
Fix list projects to return NumericId and FriendlyName

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -1966,9 +1966,11 @@ func (h *projectsListHandler) Handle(ctx context.Context, r *projectsListRequest
 	}
 
 	projectList := []*bigqueryv2.ProjectListProjects{}
-	for _, p := range projects {
+	for i, p := range projects {
 		projectList = append(projectList, &bigqueryv2.ProjectListProjects{
-			Id: p.ID,
+			Id:           p.ID,
+			NumericId:    uint64(i + 1),
+			FriendlyName: p.ID,
 		})
 	}
 	return &bigqueryv2.ProjectList{


### PR DESCRIPTION
## Fix projects.list to return NumericId and FriendlyName

Fixes #391

### Problem

The `projects.list` API endpoint only returns the `id` field for each project, but the Google Cloud BigQuery Python client expects `numericId` and `friendlyName` fields to also be present. This causes a `KeyError` when calling `client.list_projects()`.

### Reproduction

Start the emulator:
```bash
bigquery-emulator --project=test
```

Run the following Python code:
```python
from google.api_core.client_options import ClientOptions
from google.auth.credentials import AnonymousCredentials
from google.cloud import bigquery

client_options = ClientOptions(api_endpoint="http://0.0.0.0:9050")
client = bigquery.Client(
    "test",
    client_options=client_options,
    credentials=AnonymousCredentials(),
)

for project in client.list_projects():
    print(project)
```

**Result:**
```
Traceback (most recent call last):
  ...
  File ".../google/cloud/bigquery/client.py", line 178, in from_api_repr
    return cls(resource["id"], resource["numericId"], resource["friendlyName"])
KeyError: 'numericId'
```

### Fix

Add the missing `NumericId` and `FriendlyName` fields to the `ProjectListProjects` response:

```go
for i, p := range projects {
    projectList = append(projectList, &bigqueryv2.ProjectListProjects{
        Id:           p.ID,
        NumericId:    uint64(i + 1),
        FriendlyName: p.ID,
    })
}
```

- `NumericId` is assigned a sequential integer (1-indexed)
- `FriendlyName` defaults to the project ID