### PR TITLE
Fix: return HTTP 409 for duplicate datasets and jobs

### DIFF
--- a/internal/metadata/project.go
+++ b/internal/metadata/project.go
@@ -3,8 +3,14 @@ package metadata
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
+)
+
+var (
+	ErrDuplicatedDataset = errors.New("dataset is already created")
+	ErrDuplicatedJob     = errors.New("job is already created")
 )
 
 type Project struct {
@@ -69,7 +75,7 @@ func (p *Project) AddDataset(ctx context.Context, tx *sql.Tx, dataset *Dataset) 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if _, exists := p.datasetMap[dataset.ID]; exists {
-		return fmt.Errorf("dataset %s is already created", dataset.ID)
+		return fmt.Errorf("dataset %s: %w", dataset.ID, ErrDuplicatedDataset)
 	}
 	if err := dataset.Insert(ctx, tx); err != nil {
 		return err
@@ -111,7 +117,7 @@ func (p *Project) AddJob(ctx context.Context, tx *sql.Tx, job *Job) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if _, exists := p.jobMap[job.ID]; exists {
-		return fmt.Errorf("job %s is already created", job.ID)
+		return fmt.Errorf("job %s: %w", job.ID, ErrDuplicatedJob)
 	}
 	if err := job.Insert(ctx, tx); err != nil {
 		return err

--- a/server/handler.go
+++ b/server/handler.go
@@ -681,7 +681,11 @@ func (h *datasetsInsertHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		dataset: &dataset,
 	})
 	if err != nil {
-		errorResponse(ctx, w, errInternalError(err.Error()))
+		if errors.Is(err, metadata.ErrDuplicatedDataset) {
+			errorResponse(ctx, w, errDuplicate(err.Error()))
+		} else {
+			errorResponse(ctx, w, errInternalError(err.Error()))
+		}
 		return
 	}
 	encodeResponse(ctx, w, res)
@@ -1016,7 +1020,11 @@ func (h *jobsInsertHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		job:     &job,
 	})
 	if err != nil {
-		errorResponse(ctx, w, errJobInternalError(err.Error()))
+		if errors.Is(err, metadata.ErrDuplicatedJob) {
+			errorResponse(ctx, w, errDuplicate(err.Error()))
+		} else {
+			errorResponse(ctx, w, errJobInternalError(err.Error()))
+		}
 		return
 	}
 	encodeResponse(ctx, w, res)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -867,6 +867,58 @@ func TestDuplicateTable(t *testing.T) {
 	}
 }
 
+func TestDuplicateDataset(t *testing.T) {
+	const (
+		projectName = "test"
+		datasetName = "dataset1"
+	)
+
+	ctx := context.Background()
+
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.SetProject(projectName); err != nil {
+		t.Fatal(err)
+	}
+
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+
+	client, err := bigquery.NewClient(
+		ctx,
+		projectName,
+		option.WithEndpoint(testServer.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	dataset := client.Dataset(datasetName)
+	if err := dataset.Create(ctx, &bigquery.DatasetMetadata{
+		Name: datasetName,
+	}); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if err := dataset.Create(ctx, &bigquery.DatasetMetadata{
+		Name: datasetName,
+	}); err != nil {
+		ge := err.(*googleapi.Error)
+		if ge.Code != 409 {
+			t.Fatalf("expected 409 Conflict, got %d: %+v", ge.Code, ge)
+		}
+	} else {
+		t.Fatal("expected error when dataset name duplicates")
+	}
+}
+
 func TestDuplicateTableWithSchema(t *testing.T) {
 	const (
 		projectName = "test"


### PR DESCRIPTION
## Summary

When creating a dataset or job that already exists, the emulator returns HTTP 500 (InternalServerError) instead of the correct HTTP 409 (Conflict). This causes two problems for BigQuery client libraries:

1. **Retry storm**: The Python client treats 500 as a transient error and retries with exponential backoff for up to 600 seconds (~10 minutes per affected call)
2. **`exists_ok=True` bypass**: The Python client's `exists_ok` parameter only suppresses 409 errors, so the 500 bypasses it entirely

### Approach

This follows the **existing `ErrDuplicatedTable` pattern** already in the codebase (`internal/metadata/dataset.go` + `server/handler.go:2609`):

- Add `ErrDuplicatedDataset` and `ErrDuplicatedJob` sentinel errors in `internal/metadata/project.go`
- Wrap with `%w` in `AddDataset` / `AddJob` for `errors.Is` support
- Check `errors.Is` in `ServeHTTP` and use `errDuplicate()` for the HTTP response

### Addressing feedback from #184

Per @goccy's review comments on #184:

- **"Please use `errDuplicate` function in error.go"** — Done. We use the existing `errDuplicate()` in the handlers, consistent with how `ErrDuplicatedTable` is already handled
- **"It does not seem necessary to change to `*ServerError` type"** — Done. `Handle()` method signatures are unchanged; the `errors.Is` check happens in `ServeHTTP`

### Changes

| File | Change |
|------|--------|
| `internal/metadata/project.go` | Add `ErrDuplicatedDataset`, `ErrDuplicatedJob` sentinels; wrap with `%w` |
| `server/handler.go` | `datasetsInsertHandler.ServeHTTP` and `jobsInsertHandler.ServeHTTP` check `errors.Is` → `errDuplicate()` |
| `server/server_test.go` | Add `TestDuplicateDataset` (mirrors existing `TestDuplicateTable`) |

Fixes #256
Supersedes #184

## Test plan

- [x] `TestDuplicateDataset` — verifies HTTP 409 on duplicate dataset creation
- [x] `TestDuplicateTable` — existing test still passes (no regression)
- [x] `TestDataset` — existing test still passes (no regression)
- [x] `go build ./...` — compiles cleanly