### PR TITLE
fix: implement paginated results for query jobs (#326)

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -17,6 +17,7 @@ type (
 		Rows         []*TableRow              `json:"rows"`
 		TotalRows    uint64                   `json:"totalRows,string"`
 		JobComplete  bool                     `json:"jobComplete"`
+		PageToken    string                   `json:"pageToken,omitempty"`
 		TotalBytes   uint64                   `json:"-"`
 	}
 
@@ -26,6 +27,7 @@ type (
 		Rows           []*TableRow                `json:"rows"`
 		TotalRows      uint64                     `json:"totalRows,string"`
 		JobComplete    bool                       `json:"jobComplete"`
+		PageToken      string                     `json:"pageToken,omitempty"`
 		TotalBytes     int64                      `json:"-"`
 		ChangedCatalog *zetasqlite.ChangedCatalog `json:"-"`
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"encoding/base64"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -566,6 +567,46 @@ func isFormatOptionsUseInt64Timestamp(r *http.Request) bool {
 	return parseQueryValueAsBool(r, formatOptionsUseInt64TimestampParam)
 }
 
+func encodePageToken(startIndex int64) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.FormatInt(startIndex, 10)))
+}
+
+func decodePageToken(token string) (int64, error) {
+	b, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode page token: %w", err)
+	}
+	return strconv.ParseInt(string(b), 10, 64)
+}
+
+func parseQueryValueAsInt64(r *http.Request, key string) (int64, bool) {
+	queryValues := r.URL.Query()
+	values, exists := queryValues[key]
+	if !exists || len(values) != 1 {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(values[0], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+func paginateRows(rows []*internaltypes.TableRow, startIndex int64, maxResults int64) (pageRows []*internaltypes.TableRow, nextPageToken string) {
+	total := int64(len(rows))
+	if startIndex >= total {
+		return nil, ""
+	}
+	rows = rows[startIndex:]
+	if maxResults > 0 && int64(len(rows)) > maxResults {
+		pageRows = rows[:maxResults]
+		nextPageToken = encodePageToken(startIndex + maxResults)
+	} else {
+		pageRows = rows
+	}
+	return
+}
+
 func parseQueryValueAsBool(r *http.Request, key string) bool {
 	queryValues := r.URL.Query()
 	values, exists := queryValues[key]
@@ -963,11 +1004,32 @@ func (h *jobsGetQueryResultsHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 	server := serverFromContext(ctx)
 	project := projectFromContext(ctx)
 	job := jobFromContext(ctx)
+
+	var maxResults int64
+	if v, ok := parseQueryValueAsInt64(r, "maxResults"); ok {
+		maxResults = v
+	}
+
+	var startIndex int64
+	pageToken := r.URL.Query().Get("pageToken")
+	if pageToken != "" {
+		var err error
+		startIndex, err = decodePageToken(pageToken)
+		if err != nil {
+			errorResponse(ctx, w, errInvalid(fmt.Sprintf("invalid pageToken: %s", err.Error())))
+			return
+		}
+	} else if v, ok := parseQueryValueAsInt64(r, "startIndex"); ok {
+		startIndex = v
+	}
+
 	res, err := h.Handle(ctx, &jobsGetQueryResultsRequest{
 		server:            server,
 		project:           project,
 		job:               job,
 		useInt64Timestamp: isFormatOptionsUseInt64Timestamp(r),
+		maxResults:        maxResults,
+		startIndex:        startIndex,
 	})
 	if err != nil {
 		errorResponse(ctx, w, errJobInternalError(err.Error()))
@@ -981,6 +1043,8 @@ type jobsGetQueryResultsRequest struct {
 	project           *metadata.Project
 	job               *metadata.Job
 	useInt64Timestamp bool
+	maxResults        int64
+	startIndex        int64
 }
 
 func (h *jobsGetQueryResultsHandler) Handle(ctx context.Context, r *jobsGetQueryResultsRequest) (*internaltypes.GetQueryResultsResponse, error) {
@@ -989,6 +1053,7 @@ func (h *jobsGetQueryResultsHandler) Handle(ctx context.Context, r *jobsGetQuery
 		return nil, err
 	}
 	rows := internaltypes.Format(response.Schema, response.Rows, r.useInt64Timestamp)
+	pageRows, nextPageToken := paginateRows(rows, r.startIndex, r.maxResults)
 	return &internaltypes.GetQueryResultsResponse{
 		JobReference: &bigqueryv2.JobReference{
 			ProjectId: r.project.ID,
@@ -997,7 +1062,8 @@ func (h *jobsGetQueryResultsHandler) Handle(ctx context.Context, r *jobsGetQuery
 		Schema:      response.Schema,
 		TotalRows:   response.TotalRows,
 		JobComplete: true,
-		Rows:        rows,
+		Rows:        pageRows,
+		PageToken:   nextPageToken,
 	}, nil
 }
 
@@ -1758,6 +1824,45 @@ func (h *jobsQueryHandler) Handle(ctx context.Context, r *jobsQueryRequest) (*in
 	response.JobReference = &bigqueryv2.JobReference{
 		ProjectId: r.project.ID,
 		JobId:     jobID,
+	}
+
+	// Persist the job so that getQueryResults can retrieve subsequent pages.
+	jobConn, err := r.server.connMgr.Connection(ctx, r.project.ID, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connection for job: %w", err)
+	}
+	jobTx, err := jobConn.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start transaction for job: %w", err)
+	}
+	defer jobTx.RollbackIfNotCommitted()
+	if err := r.project.AddJob(
+		ctx,
+		jobTx.Tx(),
+		metadata.NewJob(
+			r.server.metaRepo,
+			r.project.ID,
+			jobID,
+			&bigqueryv2.Job{
+				JobReference: response.JobReference,
+				Status:       &bigqueryv2.JobStatus{State: "DONE"},
+			},
+			response,
+			nil,
+		),
+	); err != nil {
+		return nil, fmt.Errorf("failed to add job: %w", err)
+	}
+	if !r.queryRequest.DryRun {
+		if err := jobTx.Commit(); err != nil {
+			return nil, fmt.Errorf("failed to commit job: %w", err)
+		}
+	}
+
+	if maxResults := r.queryRequest.MaxResults; maxResults > 0 {
+		pageRows, nextPageToken := paginateRows(response.Rows, 0, maxResults)
+		response.Rows = pageRows
+		response.PageToken = nextPageToken
 	}
 	return response, nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2710,3 +2710,197 @@ func TestInformationSchema(t *testing.T) {
 	})
 
 }
+
+func TestPaginatedQueryResults(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		projectID = "test"
+		datasetID = "dataset1"
+	)
+
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(
+		server.StructSource(
+			types.NewProject(
+				projectID,
+				types.NewDataset(
+					datasetID,
+					types.NewTable(
+						"items",
+						[]*types.Column{
+							types.NewColumn("id", types.INT64),
+							types.NewColumn("name", types.STRING),
+						},
+						types.Data{
+							{"id": 1, "name": "a"},
+							{"id": 2, "name": "b"},
+							{"id": 3, "name": "c"},
+							{"id": 4, "name": "d"},
+							{"id": 5, "name": "e"},
+							{"id": 6, "name": "f"},
+							{"id": 7, "name": "g"},
+							{"id": 8, "name": "h"},
+							{"id": 9, "name": "i"},
+							{"id": 10, "name": "j"},
+						},
+					),
+				),
+			),
+		),
+	); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+
+	t.Run("getQueryResults with maxResults", func(t *testing.T) {
+		// Use the raw REST API to test pagination on getQueryResults.
+		// First, run a query via jobs.query to get a jobId.
+		queryReqBody := `{"query": "SELECT id, name FROM dataset1.items ORDER BY id", "useLegacySql": false}`
+		resp, err := http.Post(
+			testServer.URL+"/bigquery/v2/projects/test/queries",
+			"application/json",
+			bytes.NewBufferString(queryReqBody),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var queryResp map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&queryResp); err != nil {
+			t.Fatal(err)
+		}
+		jobRef, ok := queryResp["jobReference"].(map[string]interface{})
+		if !ok {
+			t.Fatal("missing jobReference")
+		}
+		jobID, ok := jobRef["jobId"].(string)
+		if !ok || jobID == "" {
+			t.Fatal("missing jobId")
+		}
+
+		// Now fetch paginated results with maxResults=4
+		var allRows []interface{}
+		pageToken := ""
+		pageCount := 0
+		for {
+			reqURL := fmt.Sprintf(
+				"%s/bigquery/v2/projects/test/queries/%s?maxResults=4",
+				testServer.URL, jobID,
+			)
+			if pageToken != "" {
+				reqURL += "&pageToken=" + url.QueryEscape(pageToken)
+			}
+			resp, err := http.Get(reqURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var pageResp map[string]interface{}
+			if err := json.NewDecoder(resp.Body).Decode(&pageResp); err != nil {
+				resp.Body.Close()
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+
+			rows, _ := pageResp["rows"].([]interface{})
+			if len(rows) > 4 {
+				t.Fatalf("page %d: expected at most 4 rows, got %d", pageCount, len(rows))
+			}
+			allRows = append(allRows, rows...)
+			pageCount++
+
+			nextToken, _ := pageResp["pageToken"].(string)
+			if nextToken == "" {
+				break
+			}
+			pageToken = nextToken
+		}
+
+		if len(allRows) != 10 {
+			t.Fatalf("expected 10 total rows across all pages, got %d", len(allRows))
+		}
+		if pageCount != 3 {
+			t.Fatalf("expected 3 pages (4+4+2), got %d", pageCount)
+		}
+	})
+
+	t.Run("jobs.query with maxResults", func(t *testing.T) {
+		// Test that jobs.query also respects maxResults in the request body.
+		queryReqBody := `{"query": "SELECT id, name FROM dataset1.items ORDER BY id", "useLegacySql": false, "maxResults": 3}`
+		resp, err := http.Post(
+			testServer.URL+"/bigquery/v2/projects/test/queries",
+			"application/json",
+			bytes.NewBufferString(queryReqBody),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var queryResp map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&queryResp); err != nil {
+			t.Fatal(err)
+		}
+
+		rows, _ := queryResp["rows"].([]interface{})
+		if len(rows) != 3 {
+			t.Fatalf("expected 3 rows in first page, got %d", len(rows))
+		}
+
+		pageToken, _ := queryResp["pageToken"].(string)
+		if pageToken == "" {
+			t.Fatal("expected non-empty pageToken since there are more results")
+		}
+
+		// Verify totalRows still reflects the full result set
+		totalRows, _ := queryResp["totalRows"].(string)
+		if totalRows != "10" {
+			t.Fatalf("expected totalRows=10, got %s", totalRows)
+		}
+	})
+
+	t.Run("go client pagination", func(t *testing.T) {
+		client, err := bigquery.NewClient(
+			ctx,
+			projectID,
+			option.WithEndpoint(testServer.URL),
+			option.WithoutAuthentication(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer client.Close()
+
+		query := client.Query("SELECT id, name FROM dataset1.items ORDER BY id")
+		query.DefaultDatasetID = datasetID
+		it, err := query.Read(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		it.PageInfo().MaxSize = 4
+
+		var allRows [][]bigquery.Value
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatal(err)
+			}
+			allRows = append(allRows, row)
+		}
+
+		if len(allRows) != 10 {
+			t.Fatalf("expected 10 total rows, got %d", len(allRows))
+		}
+	})
+}


### PR DESCRIPTION

When requesting paginated results with a `QueryJob` using `maxResults`/`pageSize`, the emulator returned **all rows** instead of respecting the page size limit.

Specifically:
- `jobsGetQueryResultsHandler` ignored the `maxResults`, `pageToken`, and `startIndex` query parameters — every call returned the full result set.
- `jobsQueryHandler` ignored `maxResults` from the request body.
- `jobs.query` did not persist the job in metadata, so subsequent `getQueryResults` calls to fetch later pages could not look up the job.

## Changes

### `internal/types/types.go`
- Added `PageToken` field (with `omitempty`) to both `GetQueryResultsResponse` and `QueryResponse` so the JSON responses include a page token when more pages are available.

### `server/handler.go`

**New helper functions:**
- `encodePageToken` / `decodePageToken` — base64-encode an integer offset as a page token and decode it back.
- `parseQueryValueAsInt64` — parse a query parameter as `int64`.
- `paginateRows` — given a full row slice, a start index, and a max page size, return the page slice and a next-page token (empty string if this is the last page).

**`jobsGetQueryResultsHandler.ServeHTTP`:**
- Parses `maxResults`, `pageToken`, and `startIndex` from the request URL.
- Decodes `pageToken` into a start index (falls back to `startIndex` if no token).
- Passes both values to `Handle`.

**`jobsGetQueryResultsHandler.Handle`:**
- Calls `paginateRows` to slice the result set and populate `PageToken` on the response.

**`jobsQueryHandler.Handle`:**
- After building the response, persists the job via `project.AddJob` so that `getQueryResults` can retrieve subsequent pages by job ID.
- If `maxResults > 0` in the request, paginates the initial response and sets `PageToken`.

### `server/server_test.go`
Added `TestPaginatedQueryResults` with three sub-tests:

1. **`getQueryResults with maxResults`** — runs a query, then fetches pages via the REST endpoint with `maxResults=4`, asserting 3 pages (4+4+2) and 10 total rows.
2. **`jobs.query with maxResults`** — sends `maxResults: 3` in the `jobs.query` request body, asserts the first page has 3 rows, a non-empty `pageToken`, and `totalRows` still reports 10.
3. **`go client pagination`** — uses the official Go client library with `PageInfo().MaxSize = 4`, iterates all rows, and asserts 10 total.

## How to test

### Run the new tests

```bash
go test ./server/ -run TestPaginatedQueryResults -v -count=1
```

Expected output: all three sub-tests pass.

### Run the full test suite

```bash
go test ./...
```

### Manual verification (optional)

1. Start the emulator:
   ```bash
   go run ./cmd/bigquery-emulator --project=test --dataset=dataset1
   ```

2. Insert some test data, then query with pagination:
   ```bash
   # Run a query
   curl -s -X POST \
     'http://localhost:9050/bigquery/v2/projects/test/queries' \
     -H 'Content-Type: application/json' \
     -d '{"query":"SELECT * FROM dataset1.your_table ORDER BY id","useLegacySql":false,"maxResults":2}' | jq .

   # Note the jobId and pageToken from the response, then fetch the next page:
   curl -s 'http://localhost:9050/bigquery/v2/projects/test/queries/JOB_ID?maxResults=2&pageToken=PAGE_TOKEN' | jq .
   ```

   Verify each page returns at most 2 rows and the last page has an empty/absent `pageToken`.
