### PR TITLE
Propagate PARTITION BY and CLUSTER BY metadata from DDL

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -1553,14 +1553,26 @@ func addTableMetadata(ctx context.Context, server *Server, spec *zetasqlite.Tabl
 		return err
 	}
 	defer tx.RollbackIfNotCommitted()
-	if _, err := createTableMetadata(ctx, tx, server, project, dataset, &bigqueryv2.Table{
+	table := &bigqueryv2.Table{
 		TableReference: &bigqueryv2.TableReference{
 			ProjectId: projectID,
 			DatasetId: datasetID,
 			TableId:   tableID,
 		},
 		Schema: &bigqueryv2.TableSchema{Fields: fields},
-	}); err != nil {
+	}
+	if len(spec.PartitionBy) > 0 {
+		table.TimePartitioning = &bigqueryv2.TimePartitioning{
+			Type:  "DAY",
+			Field: spec.PartitionBy[0],
+		}
+	}
+	if len(spec.ClusterBy) > 0 {
+		table.Clustering = &bigqueryv2.Clustering{
+			Fields: spec.ClusterBy,
+		}
+	}
+	if _, err := createTableMetadata(ctx, tx, server, project, dataset, table); err != nil {
 		return err
 	}
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
## Summary

Fixes #152.

CREATE TABLE statements with PARTITION BY or CLUSTER BY currently crash the emulator with `CREATE TABLE with PARTITION BY is unsupported`. The root cause is in go-zetasqlite, which now has a fix in goccy/go-zetasqlite#241.

This PR adds the emulator side of the fix: when a table is created via DDL with PARTITION BY or CLUSTER BY, the partition and cluster column names are read from the TableSpec and stored in the table metadata as `TimePartitioning` and `Clustering`. This means table GET responses now include the correct partitioning info, matching real BigQuery behavior.

## What changed

**server/handler.go**: Updated `addTableMetadata` to check `spec.PartitionBy` and `spec.ClusterBy`. When present, it populates `TimePartitioning` (type DAY, with the partition field) and `Clustering` (with the cluster fields) on the `bigqueryv2.Table` before persisting it.

## Scope

This is a metadata only change. No actual data partitioning or partition pruning is implemented in the underlying SQLite storage. The goal is to stop crashing on DDL that uses these clauses and to return accurate metadata in API responses.

## Dependencies

Requires goccy/go-zetasqlite#241 to be merged and released first, since the `PartitionBy` and `ClusterBy` fields on `TableSpec` are introduced there.

## Testing

Tested locally with the full emulator running on port 9050. Verified that:

1. `CREATE TABLE ... PARTITION BY DATE(col) CLUSTER BY col1, col2` succeeds (previously crashed)
2. INSERT and SELECT on partitioned tables work normally
3. Table metadata GET returns `timePartitioning` and `clustering` with the correct fields
4. All existing server tests continue to pass