### PR TITLE
Cap GoReleaser build parallelism to avoid OOM on the release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,12 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          # A single `go build` of this project peaks at ~5.6 GB RSS.
+          # GoReleaser defaults --parallelism to the CPU count (4 on
+          # ubuntu-latest), so building 4 targets at once needs ~22 GB
+          # on a 16 GB runner and the agent gets OOM-killed. Build the
+          # targets one at a time to keep memory bounded.
+          args: release --clean --parallelism 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem

The first GoReleaser run of the new release pipeline ([run 26036447466](https://github.com/goccy/bigquery-emulator/actions/runs/26036447466/job/76535812226)) failed. The `Run GoReleaser` log stops dead at `building binaries` with **four concurrent builds in flight**, then the job is finalized as `failure` ~8.5 minutes later with **no error message and no `##[error]` annotation** — even in the raw downloaded log. That signature means the runner agent itself was OOM-killed.

## Cause

A single cold `go build` of this project peaks at **~5.6 GB RSS**:

```
44.98 real   248.10 user   37.63 sys
5602304000  maximum resident set size
```

GoReleaser defaults `--parallelism` to the CPU count (4 on `ubuntu-latest`), so building four targets at once needs **~22 GB on a 16 GB runner**. The runner thrashed into swap (hence 8.5 min for sub-minute builds) and was killed. The Docker `image` job succeeded because it only builds the two linux targets via buildx.

## Fix

Pass `--parallelism 1` so targets build one at a time and memory stays bounded (~6 targets × ~45 s ≈ 5 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)