### PR TITLE
Fix a batch of v0.7.0 follow-up bugs

### DIFF
--- a/cmd/bigquery-emulator/main.go
+++ b/cmd/bigquery-emulator/main.go
@@ -124,12 +124,15 @@ func runServer(args []string, opt option) error {
 		}
 	}()
 
+	bqServer.SetListenCallback(func(httpAddr, grpcAddr string) {
+		fmt.Fprintf(os.Stdout, "[bigquery-emulator] REST server listening at %s\n", httpAddr)
+		fmt.Fprintf(os.Stdout, "[bigquery-emulator] gRPC server listening at %s\n", grpcAddr)
+	})
+
 	done := make(chan error)
 	go func() {
 		httpAddr := fmt.Sprintf("%s:%d", opt.Host, opt.HTTPPort)
 		grpcAddr := fmt.Sprintf("%s:%d", opt.Host, opt.GRPCPort)
-		fmt.Fprintf(os.Stdout, "[bigquery-emulator] REST server listening at %s\n", httpAddr)
-		fmt.Fprintf(os.Stdout, "[bigquery-emulator] gRPC server listening at %s\n", grpcAddr)
 		done <- bqServer.Serve(ctx, httpAddr, grpcAddr)
 	}()
 

--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -3,6 +3,7 @@ package contentdata
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -533,7 +534,14 @@ func (r *Repository) AddTableData(ctx context.Context, tx *connection.Tx, projec
 		if err := validateIdent("column", col.Name); err != nil {
 			return err
 		}
-		placeholders = append(placeholders, "?")
+		if col.Type == types.JSON {
+			// A JSON column cannot take a raw bound string: SQLite would store
+			// it as a JSON string literal (double-encoded). PARSE_JSON turns
+			// the bound JSON text into a proper JSON value.
+			placeholders = append(placeholders, "PARSE_JSON(?)")
+		} else {
+			placeholders = append(placeholders, "?")
+		}
 		columnsWithEscape = append(columnsWithEscape, fmt.Sprintf("`%s`", escapeIdent(col.Name)))
 	}
 
@@ -557,23 +565,35 @@ func (r *Repository) AddTableData(ctx context.Context, tx *connection.Tx, projec
 		values := make([]interface{}, 0, len(table.Columns))
 
 		for _, column := range columns {
-			if value, found := data[column.Name]; found {
-				isTimestampColumn := column.Type == types.TIMESTAMP
-				inputString, isInputString := value.(string)
-
-				if isInputString && isTimestampColumn {
-					parsedTimestamp, err := googlesqlite.TimeFromTimestampValue(inputString)
-					// If we could parse the timestamp, use it when inserting, otherwise fallback to the supplied value
-					if err == nil {
-						values = append(values, parsedTimestamp)
-						continue
-					}
-				}
-
-				values = append(values, value)
-			} else {
+			value, found := data[column.Name]
+			if !found || value == nil {
 				values = append(values, nil)
+				continue
 			}
+
+			if column.Type == types.JSON {
+				// The PARSE_JSON(?) placeholder expects JSON text. A string
+				// value is already JSON text (clients json-encode it); any
+				// other Go value is marshaled to its JSON representation.
+				jsonText, err := jsonColumnText(value)
+				if err != nil {
+					return fmt.Errorf("failed to encode JSON value for column %s: %w", column.Name, err)
+				}
+				values = append(values, jsonText)
+				continue
+			}
+
+			inputString, isInputString := value.(string)
+			if isInputString && column.Type == types.TIMESTAMP {
+				parsedTimestamp, err := googlesqlite.TimeFromTimestampValue(inputString)
+				// If we could parse the timestamp, use it when inserting, otherwise fallback to the supplied value
+				if err == nil {
+					values = append(values, parsedTimestamp)
+					continue
+				}
+			}
+
+			values = append(values, value)
 		}
 
 		if _, err := stmt.ExecContext(ctx, values...); err != nil {
@@ -582,6 +602,20 @@ func (r *Repository) AddTableData(ctx context.Context, tx *connection.Tx, projec
 	}
 
 	return nil
+}
+
+// jsonColumnText returns the JSON text for a value bound to a JSON column.
+// A string is assumed to already hold JSON text (the form clients send for
+// JSON columns); any other value is marshaled to its JSON representation.
+func jsonColumnText(value interface{}) (string, error) {
+	if s, ok := value.(string); ok {
+		return s, nil
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
 }
 
 // TableDeletion identifies one table or view to drop. A view must be dropped

--- a/internal/metadata/table.go
+++ b/internal/metadata/table.go
@@ -17,7 +17,34 @@ type Table struct {
 	repo      *Repository
 }
 
-func (t *Table) Update(ctx context.Context, tx *sql.Tx, metadata map[string]interface{}) error {
+// Patch shallow-merges the provided top-level fields into the table metadata
+// (the semantics of bigquery.tables.patch) and persists the result.
+func (t *Table) Patch(ctx context.Context, tx *sql.Tx, patch map[string]interface{}) error {
+	if t.metadata == nil {
+		t.metadata = map[string]interface{}{}
+	}
+	for k, v := range patch {
+		t.metadata[k] = v
+	}
+	return t.repo.UpdateTable(ctx, tx, t)
+}
+
+// Replace overwrites the table metadata with the provided resource (the
+// semantics of bigquery.tables.update), preserving the immutable identity
+// fields when the caller omits them.
+func (t *Table) Replace(ctx context.Context, tx *sql.Tx, metadata map[string]interface{}) error {
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+	for _, key := range []string{"id", "kind", "type", "tableReference", "creationTime", "selfLink"} {
+		if _, ok := metadata[key]; ok {
+			continue
+		}
+		if v, exists := t.metadata[key]; exists {
+			metadata[key] = v
+		}
+	}
+	t.metadata = metadata
 	return t.repo.UpdateTable(ctx, tx, t)
 }
 

--- a/server/gcs_internal_test.go
+++ b/server/gcs_internal_test.go
@@ -1,0 +1,33 @@
+package server
+
+import "testing"
+
+// TestGCSClientOptions covers the credential fallback added for #347: a load
+// from gs:// must not hard-fail with "could not find default credentials"
+// when no GCS emulator and no Application Default Credentials are configured.
+func TestGCSClientOptions(t *testing.T) {
+	t.Run("emulator host configured", func(t *testing.T) {
+		t.Setenv("STORAGE_EMULATOR_HOST", "http://localhost:1234")
+		t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+		if got := len(gcsClientOptions(true)); got != 3 {
+			t.Errorf("expected 3 options for emulator reads, got %d", got)
+		}
+		if got := len(gcsClientOptions(false)); got != 2 {
+			t.Errorf("expected 2 options for emulator writes, got %d", got)
+		}
+	})
+	t.Run("no credentials falls back to anonymous", func(t *testing.T) {
+		t.Setenv("STORAGE_EMULATOR_HOST", "")
+		t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+		if got := len(gcsClientOptions(true)); got != 1 {
+			t.Errorf("expected anonymous fallback (1 option), got %d", got)
+		}
+	})
+	t.Run("application default credentials honored", func(t *testing.T) {
+		t.Setenv("STORAGE_EMULATOR_HOST", "")
+		t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/path/to/creds.json")
+		if got := gcsClientOptions(true); got != nil {
+			t.Errorf("expected no extra options when ADC is set, got %d", len(got))
+		}
+	})
+}

--- a/server/handler.go
+++ b/server/handler.go
@@ -43,6 +43,18 @@ func errorResponse(ctx context.Context, w http.ResponseWriter, e *ServerError) {
 	w.Write(e.Response())
 }
 
+// uploadErrorResponse renders an error returned by the upload content handler.
+// When the handler produced a typed *ServerError (e.g. a missing dataset), its
+// HTTP status is preserved; any other failure is reported as a job error.
+func uploadErrorResponse(ctx context.Context, w http.ResponseWriter, err error) {
+	var serr *ServerError
+	if errors.As(err, &serr) {
+		errorResponse(ctx, w, serr)
+		return
+	}
+	errorResponse(ctx, w, errJobInternalError(err.Error()))
+}
+
 func encodeResponse(ctx context.Context, w http.ResponseWriter, response interface{}) {
 	b, err := json.Marshal(response)
 	if err != nil {
@@ -143,6 +155,26 @@ type UploadJob struct {
 	Configuration *UploadJobConfiguration  `json:"configuration"`
 }
 
+// normalize fills in fields that some client libraries omit from the upload
+// metadata. The Node.js client in particular sends no jobReference, which
+// previously caused a nil pointer dereference when the handler read the job
+// id. A missing job id is generated so the upload still gets a stable handle.
+func (j *UploadJob) normalize(projectID string) *ServerError {
+	if j.Configuration == nil || j.Configuration.Load == nil {
+		return errInvalid("upload job is missing configuration.load")
+	}
+	if j.JobReference == nil {
+		j.JobReference = &bigqueryv2.JobReference{}
+	}
+	if j.JobReference.JobId == "" {
+		j.JobReference.JobId = randomID()
+	}
+	if j.JobReference.ProjectId == "" {
+		j.JobReference.ProjectId = projectID
+	}
+	return nil
+}
+
 func (j *UploadJob) ToJob() *bigqueryv2.Job {
 	load := j.Configuration.Load
 	skipLeadingRows, _ := load.SkipLeadingRows.Int64()
@@ -217,6 +249,10 @@ func (h *uploadHandler) serveMultipart(w http.ResponseWriter, r *http.Request) {
 		errorResponse(ctx, w, errInvalid(fmt.Sprintf("failed to decode job: %s", err.Error())))
 		return
 	}
+	if serr := job.normalize(project.ID); serr != nil {
+		errorResponse(ctx, w, serr)
+		return
+	}
 	uploadJob, err := h.Handle(ctx, &uploadRequest{
 		server:  server,
 		project: project,
@@ -240,7 +276,7 @@ func (h *uploadHandler) serveMultipart(w http.ResponseWriter, r *http.Request) {
 		reader:  p,
 	})
 	if err != nil {
-		errorResponse(ctx, w, errInternalError(err.Error()))
+		uploadErrorResponse(ctx, w, err)
 		return
 	}
 	encodeResponse(ctx, w, uploadJob.Content())
@@ -253,6 +289,10 @@ func (h *uploadHandler) serveResumable(w http.ResponseWriter, r *http.Request) {
 	var job UploadJob
 	if err := json.NewDecoder(r.Body).Decode(&job); err != nil {
 		errorResponse(ctx, w, errInvalid(fmt.Sprintf("failed to decode job: %s", err.Error())))
+		return
+	}
+	if serr := job.normalize(project.ID); serr != nil {
+		errorResponse(ctx, w, serr)
 		return
 	}
 	res, err := h.Handle(ctx, &uploadRequest{
@@ -330,13 +370,17 @@ func (h *uploadContentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 	jobID := uploadID[0]
 	job := project.Job(jobID)
+	if job == nil {
+		errorResponse(ctx, w, errNotFound(fmt.Sprintf("upload job %s is not found", jobID)))
+		return
+	}
 	if err := h.Handle(ctx, &uploadContentRequest{
 		server:  server,
 		project: project,
 		job:     job,
 		reader:  r.Body,
 	}); err != nil {
-		errorResponse(ctx, w, errJobInternalError(err.Error()))
+		uploadErrorResponse(ctx, w, err)
 		return
 	}
 	content := job.Content()
@@ -403,7 +447,13 @@ func (h *uploadContentHandler) normalizeColumnNameForJSONData(columnMap map[stri
 func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentRequest) error {
 	load := r.job.Content().Configuration.Load
 	tableRef := load.DestinationTable
+	if tableRef == nil {
+		return errInvalid("load job is missing configuration.load.destinationTable")
+	}
 	dataset := r.project.Dataset(tableRef.DatasetId)
+	if dataset == nil {
+		return errNotFound(fmt.Sprintf("dataset %q is not found", tableRef.DatasetId))
+	}
 	table := dataset.Table(tableRef.TableId)
 	// The write disposition only matters for a table that already exists; a
 	// freshly created one is empty regardless.
@@ -1190,17 +1240,33 @@ const (
 	gcsURIPrefix           = "gs://"
 )
 
-func (h *jobsInsertHandler) importFromGCS(ctx context.Context, r *jobsInsertRequest) (*bigqueryv2.Job, error) {
-	var opts []option.ClientOption
+// gcsClientOptions builds the option set for a Cloud Storage client.
+//
+//   - When STORAGE_EMULATOR_HOST is set, the client targets that GCS emulator
+//     with authentication disabled.
+//   - Otherwise, if no Application Default Credentials are configured, the
+//     client falls back to anonymous access so that loads from public buckets
+//     succeed instead of failing with "could not find default credentials".
+//   - When GOOGLE_APPLICATION_CREDENTIALS is set, those credentials are used.
+func gcsClientOptions(jsonReads bool) []option.ClientOption {
 	if host := os.Getenv(gcsEmulatorHostEnvName); host != "" {
-		opts = append(
-			opts,
+		opts := []option.ClientOption{
 			option.WithEndpoint(fmt.Sprintf("%s/storage/v1/", host)),
-			storage.WithJSONReads(),
 			option.WithoutAuthentication(),
-		)
+		}
+		if jsonReads {
+			opts = append(opts, storage.WithJSONReads())
+		}
+		return opts
 	}
-	client, err := storage.NewClient(ctx, opts...)
+	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
+		return []option.ClientOption{option.WithoutAuthentication()}
+	}
+	return nil
+}
+
+func (h *jobsInsertHandler) importFromGCS(ctx context.Context, r *jobsInsertRequest) (*bigqueryv2.Job, error) {
+	client, err := storage.NewClient(ctx, gcsClientOptions(true)...)
 	if err != nil {
 		return nil, err
 	}
@@ -1337,15 +1403,7 @@ func (h *jobsInsertHandler) importFromGCSObject(ctx context.Context, r *jobsInse
 }
 
 func (h *jobsInsertHandler) exportToGCS(ctx context.Context, r *jobsInsertRequest) (*bigqueryv2.Job, error) {
-	var opts []option.ClientOption
-	if host := os.Getenv(gcsEmulatorHostEnvName); host != "" {
-		opts = append(
-			opts,
-			option.WithEndpoint(fmt.Sprintf("%s/storage/v1/", host)),
-			option.WithoutAuthentication(),
-		)
-	}
-	client, err := storage.NewClient(ctx, opts...)
+	client, err := storage.NewClient(ctx, gcsClientOptions(false)...)
 	if err != nil {
 		return nil, err
 	}
@@ -2694,7 +2752,35 @@ func (h *tablesGetHandler) Handle(ctx context.Context, r *tablesGetRequest) (*bi
 	if err != nil {
 		return nil, fmt.Errorf("failed to get table content: %w", err)
 	}
+	// Populate NumRows from the backing table so clients that depend on it
+	// (e.g. Table.getNumRows) observe an accurate count. Views and external
+	// tables have no backing row store and are left untouched.
+	if table.Type == "" || table.Type == "TABLE" {
+		if numRows, err := h.countRows(ctx, r); err == nil {
+			table.NumRows = uint64(numRows)
+		}
+	}
 	return table, nil
+}
+
+func (h *tablesGetHandler) countRows(ctx context.Context, r *tablesGetRequest) (int64, error) {
+	conn, err := r.server.connMgr.Connection(ctx, r.project.ID, r.dataset.ID)
+	if err != nil {
+		return 0, err
+	}
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.RollbackIfNotCommitted()
+	count, err := r.server.contentRepo.CountTableRows(ctx, tx, r.project.ID, r.dataset.ID, r.table.ID)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func (h *tablesGetIamPolicyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -2813,6 +2899,9 @@ func createTableMetadata(ctx context.Context, tx *connection.Tx, server *Server,
 }
 
 func (h *tablesInsertHandler) Handle(ctx context.Context, r *tablesInsertRequest) (*bigqueryv2.Table, *ServerError) {
+	if r.table.ExternalDataConfiguration != nil {
+		return h.handleExternalTable(ctx, r)
+	}
 	conn, err := r.server.connMgr.Connection(ctx, r.project.ID, r.dataset.ID)
 	if err != nil {
 		return nil, errInternalError(err.Error())
@@ -2851,6 +2940,99 @@ func (h *tablesInsertHandler) Handle(ctx context.Context, r *tablesInsertRequest
 		return nil, errInternalError(fmt.Errorf("failed to commit table: %w", err).Error())
 	}
 	return table, nil
+}
+
+// handleExternalTable materializes an external table's source data into a
+// backing table so the table is registered with the query engine and can be
+// queried. Real BigQuery reads an external table live on every query; the
+// emulator snapshots the source at creation time, which is enough to make
+// the table queryable.
+func (h *tablesInsertHandler) handleExternalTable(ctx context.Context, r *tablesInsertRequest) (*bigqueryv2.Table, *ServerError) {
+	edc := r.table.ExternalDataConfiguration
+	tableRef := r.table.TableReference
+	if tableRef == nil {
+		return nil, errInvalid("external table is missing tableReference")
+	}
+	if tableRef.ProjectId == "" {
+		tableRef.ProjectId = r.project.ID
+	}
+	if tableRef.DatasetId == "" {
+		tableRef.DatasetId = r.dataset.ID
+	}
+	if len(edc.SourceUris) == 0 {
+		return nil, errInvalid("external table is missing sourceUris")
+	}
+
+	// Translate the external data configuration into a load job and route it
+	// through the existing load pipeline, which creates the backing table and
+	// loads the rows (inferring the schema when autodetect is requested).
+	load := &bigqueryv2.JobConfigurationLoad{
+		DestinationTable:  tableRef,
+		SourceUris:        edc.SourceUris,
+		SourceFormat:      edc.SourceFormat,
+		Autodetect:        edc.Autodetect,
+		Schema:            edc.Schema,
+		CreateDisposition: "CREATE_IF_NEEDED",
+	}
+	if load.Schema == nil {
+		load.Schema = r.table.Schema
+	}
+	if csv := edc.CsvOptions; csv != nil {
+		load.Quote = csv.Quote
+		load.FieldDelimiter = csv.FieldDelimiter
+		load.SkipLeadingRows = csv.SkipLeadingRows
+		load.AllowJaggedRows = csv.AllowJaggedRows
+		load.AllowQuotedNewlines = csv.AllowQuotedNewlines
+		load.Encoding = csv.Encoding
+	}
+	job := &bigqueryv2.Job{
+		JobReference:  &bigqueryv2.JobReference{JobId: randomID(), ProjectId: r.project.ID},
+		Configuration: &bigqueryv2.JobConfiguration{Load: load},
+	}
+	if _, err := (&jobsInsertHandler{}).importFromGCS(ctx, &jobsInsertRequest{
+		server:  r.server,
+		project: r.project,
+		job:     job,
+	}); err != nil {
+		return nil, errInvalid(fmt.Sprintf("failed to load external table data: %s", err))
+	}
+
+	// The load created a plain table; record the external configuration on
+	// its metadata so it round-trips on tables.get and tables.list.
+	table := r.dataset.Table(tableRef.TableId)
+	if table == nil {
+		return nil, errInternalError("external table backing data was not created")
+	}
+	content, err := table.Content()
+	if err != nil {
+		return nil, errInternalError(err.Error())
+	}
+	content.ExternalDataConfiguration = edc
+	content.Type = string(ExternalTableType)
+	encoded, err := json.Marshal(content)
+	if err != nil {
+		return nil, errInternalError(err.Error())
+	}
+	var newMetadata map[string]interface{}
+	if err := json.Unmarshal(encoded, &newMetadata); err != nil {
+		return nil, errInternalError(err.Error())
+	}
+	conn, err := r.server.connMgr.Connection(ctx, r.project.ID, r.dataset.ID)
+	if err != nil {
+		return nil, errInternalError(err.Error())
+	}
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return nil, errInternalError(err.Error())
+	}
+	defer tx.RollbackIfNotCommitted()
+	if err := table.Replace(ctx, tx.Tx(), newMetadata); err != nil {
+		return nil, errInternalError(err.Error())
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, errInternalError(err.Error())
+	}
+	return content, nil
 }
 
 func (h *tablesListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -2955,13 +3137,15 @@ func (h *tablesPatchHandler) Handle(ctx context.Context, r *tablesPatchRequest) 
 		return nil, err
 	}
 	defer tx.RollbackIfNotCommitted()
-	if err := r.table.Update(ctx, tx.Tx(), tableMetadata); err != nil {
+	if err := r.table.Patch(ctx, tx.Tx(), tableMetadata); err != nil {
 		return nil, err
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	return r.newTable, nil
+	// Return the full, merged table resource (kind/type/id/creationTime
+	// included) rather than echoing the request body.
+	return r.table.Content()
 }
 
 func (h *tablesSetIamPolicyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -3012,11 +3196,17 @@ func (h *tablesUpdateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	project := projectFromContext(ctx)
 	dataset := datasetFromContext(ctx)
 	table := tableFromContext(ctx)
+	var newTable bigqueryv2.Table
+	if err := json.NewDecoder(r.Body).Decode(&newTable); err != nil {
+		errorResponse(ctx, w, errInvalid(err.Error()))
+		return
+	}
 	res, err := h.Handle(ctx, &tablesUpdateRequest{
-		server:  server,
-		project: project,
-		dataset: dataset,
-		table:   table,
+		server:   server,
+		project:  project,
+		dataset:  dataset,
+		table:    table,
+		newTable: &newTable,
 	})
 	if err != nil {
 		errorResponse(ctx, w, errInternalError(err.Error()))
@@ -3026,14 +3216,39 @@ func (h *tablesUpdateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 }
 
 type tablesUpdateRequest struct {
-	server  *Server
-	project *metadata.Project
-	dataset *metadata.Dataset
-	table   *metadata.Table
+	server   *Server
+	project  *metadata.Project
+	dataset  *metadata.Dataset
+	table    *metadata.Table
+	newTable *bigqueryv2.Table
 }
 
 func (h *tablesUpdateHandler) Handle(ctx context.Context, r *tablesUpdateRequest) (*bigqueryv2.Table, error) {
-	return nil, fmt.Errorf("unsupported bigquery.tables.update")
+	encodedTableData, err := json.Marshal(r.newTable)
+	if err != nil {
+		return nil, err
+	}
+	var tableMetadata map[string]interface{}
+	if err := json.Unmarshal(encodedTableData, &tableMetadata); err != nil {
+		return nil, err
+	}
+
+	conn, err := r.server.connMgr.Connection(ctx, r.project.ID, r.dataset.ID)
+	if err != nil {
+		return nil, err
+	}
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.RollbackIfNotCommitted()
+	if err := r.table.Replace(ctx, tx.Tx(), tableMetadata); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return r.table.Content()
 }
 
 type defaultHandler struct{}

--- a/server/loader.go
+++ b/server/loader.go
@@ -39,21 +39,60 @@ func (s *Server) addProject(ctx context.Context, project *types.Project) error {
 	if err != nil {
 		return err
 	}
-	if found != nil {
-		if err := s.metaRepo.UpdateProject(ctx, tx.Tx(), p); err != nil {
-			return err
-		}
-	} else {
+	if found == nil {
+		// Brand-new project: insert the project and every source-described
+		// dataset and table.
 		if err := s.metaRepo.AddProjectIfNotExists(ctx, tx.Tx(), p); err != nil {
 			return err
 		}
-	}
-	for _, dataset := range p.Datasets() {
-		if err := dataset.Insert(ctx, tx.Tx()); err != nil {
+		for _, dataset := range p.Datasets() {
+			if err := dataset.Insert(ctx, tx.Tx()); err != nil {
+				return err
+			}
+			for _, table := range dataset.Tables() {
+				if err := table.Insert(ctx, tx.Tx()); err != nil {
+					return err
+				}
+			}
+		}
+		if err := tx.Commit(); err != nil {
 			return err
 		}
+		return nil
+	}
+
+	// The project already exists. This happens on every restart against a
+	// persisted database: the project, its datasets and tables are already
+	// stored. Reconcile the source-described objects with what is stored,
+	// inserting only what is missing, so that re-running the binary does not
+	// fail with a UNIQUE constraint violation and does not drop datasets or
+	// tables created at runtime.
+	for _, dataset := range p.Datasets() {
+		foundDataset := found.Dataset(dataset.ID)
+		if foundDataset == nil {
+			// New dataset: insert it and link it into the existing project.
+			if err := found.AddDataset(ctx, tx.Tx(), dataset); err != nil {
+				return err
+			}
+			for _, table := range dataset.Tables() {
+				if err := table.Insert(ctx, tx.Tx()); err != nil {
+					return err
+				}
+			}
+			continue
+		}
 		for _, table := range dataset.Tables() {
-			if err := table.Insert(ctx, tx.Tx()); err != nil {
+			if foundDataset.Table(table.ID) != nil {
+				// The table already exists; refresh its metadata.
+				if err := s.metaRepo.UpdateTable(ctx, tx.Tx(), table); err != nil {
+					return err
+				}
+				continue
+			}
+			// New table in an existing dataset: AddTable inserts the table and
+			// rewrites the dataset's table list as the union of the persisted
+			// and newly added tables.
+			if err := foundDataset.AddTable(ctx, tx.Tx(), table); err != nil {
 				return err
 			}
 		}

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/gorilla/mux"
@@ -12,6 +13,21 @@ import (
 
 	"github.com/goccy/bigquery-emulator/internal/logger"
 )
+
+// methodOverrideMiddleware honors the X-HTTP-Method-Override header on POST
+// requests. The Java BigQuery client tunnels PATCH (and other verbs) through
+// POST with this header by default; without translating it here the request
+// would never match the method-specific route registered with the router.
+func methodOverrideMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			if override := strings.TrimSpace(r.Header.Get("X-HTTP-Method-Override")); override != "" {
+				r.Method = strings.ToUpper(override)
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
 
 func sequentialAccessMiddleware() func(http.Handler) http.Handler {
 	var mu sync.Mutex

--- a/server/server.go
+++ b/server/server.go
@@ -21,17 +21,26 @@ import (
 )
 
 type Server struct {
-	Handler      http.Handler
-	storage      Storage
-	db           *sql.DB
-	loggerConfig *zap.Config
-	logger       *zap.Logger
-	connMgr      *connection.Manager
-	metaRepo     *metadata.Repository
-	contentRepo  *contentdata.Repository
-	fileCleanup  func() error
-	httpServer   *http.Server
-	grpcServer   *grpc.Server
+	Handler        http.Handler
+	storage        Storage
+	db             *sql.DB
+	loggerConfig   *zap.Config
+	logger         *zap.Logger
+	connMgr        *connection.Manager
+	metaRepo       *metadata.Repository
+	contentRepo    *contentdata.Repository
+	fileCleanup    func() error
+	httpServer     *http.Server
+	grpcServer     *grpc.Server
+	listenCallback func(httpAddr, grpcAddr string)
+}
+
+// SetListenCallback registers a function invoked once the HTTP and gRPC
+// listeners are bound, with the addresses they are actually listening on
+// (useful when a port of 0 was requested). It exists so the CLI can report
+// the bound addresses; the library itself writes nothing to stdout.
+func (s *Server) SetListenCallback(callback func(httpAddr, grpcAddr string)) {
+	s.listenCallback = callback
 }
 
 func New(storage Storage) (*Server, error) {
@@ -95,7 +104,9 @@ func New(storage Storage) (*Server, error) {
 	r.Use(withTableMiddleware())
 	r.Use(withModelMiddleware())
 	r.Use(withRoutineMiddleware())
-	server.Handler = r
+	// The method-override wrapper runs before mux matches a route, so a
+	// tunneled PATCH/PUT/DELETE reaches the correct method-specific handler.
+	server.Handler = methodOverrideMiddleware(r)
 	return server, nil
 }
 
@@ -228,7 +239,15 @@ func (s *Server) Serve(ctx context.Context, httpAddr, grpcAddr string) error {
 	}
 	grpcListener, err := net.Listen("tcp", grpcAddr)
 	if err != nil {
+		httpListener.Close()
 		return err
+	}
+
+	// Hand the actually bound addresses to the caller. With a requested port
+	// of 0 the kernel assigns a free port, so httpAddr / grpcAddr are not the
+	// real addresses. The library never writes to stdout itself.
+	if s.listenCallback != nil {
+		s.listenCallback(httpListener.Addr().String(), grpcListener.Addr().String())
 	}
 
 	var eg errgroup.Group

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"net"
 	"net/http"
 	"net/url"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -3203,5 +3205,571 @@ func TestConcurrentQueries(t *testing.T) {
 	close(errCh)
 	for err := range errCh {
 		t.Error(err)
+	}
+}
+
+// httpJSON issues a request with an optional body and decodes the JSON
+// response. It is used to exercise REST-level behavior the typed client hides.
+func httpJSON(t *testing.T, method, target, body string, headers map[string]string) (int, map[string]any) {
+	t.Helper()
+	var rdr io.Reader
+	if body != "" {
+		rdr = bytes.NewReader([]byte(body))
+	}
+	req, err := http.NewRequest(method, target, rdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if len(bytes.TrimSpace(data)) > 0 {
+		if err := json.Unmarshal(data, &out); err != nil {
+			t.Fatalf("%s %s: cannot decode response (status %d): %s", method, target, resp.StatusCode, data)
+		}
+	}
+	return resp.StatusCode, out
+}
+
+// queryRows extracts the cell values of every row in a jobs.query response.
+func queryRows(t *testing.T, body map[string]any) [][]string {
+	t.Helper()
+	rowsRaw, _ := body["rows"].([]any)
+	rows := make([][]string, 0, len(rowsRaw))
+	for _, r := range rowsRaw {
+		fields, _ := r.(map[string]any)["f"].([]any)
+		vals := make([]string, 0, len(fields))
+		for _, f := range fields {
+			v := f.(map[string]any)["v"]
+			if v == nil {
+				vals = append(vals, "<nil>")
+				continue
+			}
+			vals = append(vals, fmt.Sprint(v))
+		}
+		rows = append(rows, vals)
+	}
+	return rows
+}
+
+type valueRow map[string]bigquery.Value
+
+func (r valueRow) Save() (map[string]bigquery.Value, string, error) { return r, "", nil }
+
+// TestPersistedDatabaseRestart covers #237/#397 (re-running the binary against
+// a persisted database must not fail with a UNIQUE constraint violation) and
+// #207 (datasets and their data must survive a restart).
+func TestPersistedDatabaseRestart(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "dataset1"
+		tableID   = "t1"
+	)
+	ctx := context.Background()
+	dbFile := filepath.Join(t.TempDir(), "emulator.db")
+	storage := server.Storage(fmt.Sprintf("file:%s?cache=shared", dbFile))
+
+	// startRun mirrors what the CLI does on boot: open the database, register
+	// the project, and load the --dataset-equivalent source.
+	startRun := func() (*server.Server, *server.TestServer, *bigquery.Client) {
+		t.Helper()
+		s, err := server.New(storage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.SetProject(projectID); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Load(server.StructSource(types.NewProject(projectID, types.NewDataset(datasetID)))); err != nil {
+			t.Fatalf("loading the persisted project must be idempotent: %+v", err)
+		}
+		ts := s.TestServer()
+		c, err := bigquery.NewClient(ctx, projectID,
+			option.WithEndpoint(ts.URL), option.WithoutAuthentication())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return s, ts, c
+	}
+
+	// First run: create a table and stream three rows.
+	s1, ts1, c1 := startRun()
+	table := c1.Dataset(datasetID).Table(tableID)
+	if err := table.Create(ctx, &bigquery.TableMetadata{
+		Schema: bigquery.Schema{{Name: "x", Type: bigquery.IntegerFieldType}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := table.Inserter().Put(ctx, []valueRow{{"x": 1}, {"x": 2}, {"x": 3}}); err != nil {
+		t.Fatal(err)
+	}
+	c1.Close()
+	ts1.Close()
+	if err := s1.Stop(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second run against the same database file.
+	s2, ts2, c2 := startRun()
+	defer func() {
+		c2.Close()
+		ts2.Close()
+		s2.Stop(ctx)
+	}()
+
+	// #207: the dataset is still present in the REST catalog.
+	datasetIter := c2.Datasets(ctx)
+	var datasetIDs []string
+	for {
+		ds, err := datasetIter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		datasetIDs = append(datasetIDs, ds.DatasetID)
+	}
+	if len(datasetIDs) != 1 || datasetIDs[0] != datasetID {
+		t.Fatalf("dataset did not survive restart: got %v", datasetIDs)
+	}
+
+	// The table and its rows survive too.
+	it, err := c2.Query(fmt.Sprintf("SELECT COUNT(*) FROM %s.%s", datasetID, tableID)).Read(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var row []bigquery.Value
+	if err := it.Next(&row); err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprint(row[0]); got != "3" {
+		t.Fatalf("expected 3 rows to survive restart, got %s", got)
+	}
+}
+
+// TestTableNumRows covers #339/#249: tables.get must populate numRows.
+func TestTableNumRows(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "dataset1"
+		tableID   = "t1"
+	)
+	ctx := context.Background()
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(
+		types.NewProject(projectID, types.NewDataset(datasetID)),
+	)); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+	client, err := bigquery.NewClient(ctx, projectID,
+		option.WithEndpoint(testServer.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	table := client.Dataset(datasetID).Table(tableID)
+	if err := table.Create(ctx, &bigquery.TableMetadata{
+		Schema: bigquery.Schema{{Name: "x", Type: bigquery.IntegerFieldType}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := table.Inserter().Put(ctx, []valueRow{{"x": 1}, {"x": 2}, {"x": 3}}); err != nil {
+		t.Fatal(err)
+	}
+	md, err := table.Metadata(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if md.NumRows != 3 {
+		t.Fatalf("expected numRows=3, got %d", md.NumRows)
+	}
+}
+
+// TestTableUpdateHandlers covers #293/#363 (tables.patch must apply the body
+// and return a full Table resource), #362 (the X-HTTP-Method-Override header
+// must be honored) and #412 (tables.update must be implemented).
+func TestTableUpdateHandlers(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "dataset1"
+		tableID   = "t1"
+	)
+	ctx := context.Background()
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(
+		types.NewProject(projectID, types.NewDataset(datasetID)),
+	)); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+	client, err := bigquery.NewClient(ctx, projectID,
+		option.WithEndpoint(testServer.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	if err := client.Dataset(datasetID).Table(tableID).Create(ctx, &bigquery.TableMetadata{
+		Schema: bigquery.Schema{{Name: "x", Type: bigquery.IntegerFieldType}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	tableURL := fmt.Sprintf("%s/projects/%s/datasets/%s/tables/%s",
+		testServer.URL, projectID, datasetID, tableID)
+
+	// #293/#363: PATCH applies the body and returns a full Table resource.
+	code, body := httpJSON(t, http.MethodPatch, tableURL, `{"description":"patched"}`, nil)
+	if code != http.StatusOK {
+		t.Fatalf("patch: expected 200, got %d (%v)", code, body)
+	}
+	for _, key := range []string{"kind", "type", "id", "creationTime"} {
+		if body[key] == nil || body[key] == "" {
+			t.Errorf("patch response is missing %q: %v", key, body)
+		}
+	}
+	if body["description"] != "patched" {
+		t.Errorf("patch did not apply description: %v", body["description"])
+	}
+	// The change is persisted, not merely echoed.
+	if _, got := httpJSON(t, http.MethodGet, tableURL, "", nil); got["description"] != "patched" {
+		t.Errorf("patched description was not persisted: %v", got["description"])
+	}
+
+	// #362: a POST tunneling PATCH via X-HTTP-Method-Override is routed to the
+	// patch handler.
+	code, body = httpJSON(t, http.MethodPost, tableURL, `{"friendlyName":"viaOverride"}`,
+		map[string]string{"X-HTTP-Method-Override": "PATCH"})
+	if code != http.StatusOK {
+		t.Fatalf("method override: expected 200, got %d (%v)", code, body)
+	}
+	if body["friendlyName"] != "viaOverride" {
+		t.Errorf("method override patch did not apply: %v", body["friendlyName"])
+	}
+
+	// #412: tables.update (PUT) replaces the resource instead of returning
+	// "unsupported".
+	put := `{"tableReference":{"projectId":"test","datasetId":"dataset1","tableId":"t1"},` +
+		`"schema":{"fields":[{"name":"x","type":"INTEGER"}]},"friendlyName":"viaPut"}`
+	code, body = httpJSON(t, http.MethodPut, tableURL, put, nil)
+	if code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d (%v)", code, body)
+	}
+	if body["friendlyName"] != "viaPut" {
+		t.Errorf("update did not apply friendlyName: %v", body["friendlyName"])
+	}
+}
+
+// TestJSONColumnInsertAll covers #144: a JSON column must accept both a
+// json-encoded string and a native JSON object through tabledata.insertAll.
+func TestJSONColumnInsertAll(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "dataset1"
+		tableID   = "jt"
+	)
+	ctx := context.Background()
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(
+		types.NewProject(projectID, types.NewDataset(datasetID)),
+	)); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+	base := fmt.Sprintf("%s/projects/%s/datasets/%s", testServer.URL, projectID, datasetID)
+
+	if code, body := httpJSON(t, http.MethodPost, base+"/tables",
+		`{"tableReference":{"projectId":"test","datasetId":"dataset1","tableId":"jt"},`+
+			`"schema":{"fields":[{"name":"id","type":"INTEGER"},{"name":"data","type":"JSON"}]}}`,
+		nil); code != http.StatusOK {
+		t.Fatalf("create table: %d (%v)", code, body)
+	}
+	// A json-encoded string value.
+	if code, body := httpJSON(t, http.MethodPost, base+"/tables/jt/insertAll",
+		`{"rows":[{"json":{"id":"1","data":"{\"name\":\"Alice\"}"}}]}`, nil); code != http.StatusOK {
+		t.Fatalf("insert json string: %d (%v)", code, body)
+	}
+	// A native JSON object value (previously panicked).
+	if code, body := httpJSON(t, http.MethodPost, base+"/tables/jt/insertAll",
+		`{"rows":[{"json":{"id":"2","data":{"name":"Bob"}}}]}`, nil); code != http.StatusOK {
+		t.Fatalf("insert json object: %d (%v)", code, body)
+	}
+
+	code, body := httpJSON(t, http.MethodPost,
+		fmt.Sprintf("%s/projects/%s/queries", testServer.URL, projectID),
+		`{"query":"SELECT id, JSON_VALUE(data.name) FROM dataset1.jt ORDER BY id","useLegacySql":false}`,
+		nil)
+	if code != http.StatusOK {
+		t.Fatalf("query: %d (%v)", code, body)
+	}
+	got := queryRows(t, body)
+	want := [][]string{{"1", "Alice"}, {"2", "Bob"}}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("JSON column round-trip mismatch: got %v want %v", got, want)
+	}
+}
+
+// multipartUpload builds a multipart/related body for the jobs upload endpoint.
+func multipartUpload(jobJSON, data string) (contentType, bodyText string) {
+	const boundary = "BQEMUTESTBOUNDARY"
+	var b strings.Builder
+	b.WriteString("--" + boundary + "\r\nContent-Type: application/json\r\n\r\n")
+	b.WriteString(jobJSON + "\r\n")
+	b.WriteString("--" + boundary + "\r\nContent-Type: application/octet-stream\r\n\r\n")
+	b.WriteString(data + "\r\n")
+	b.WriteString("--" + boundary + "--\r\n")
+	return "multipart/related; boundary=" + boundary, b.String()
+}
+
+// TestUploadWithoutJobReference covers #136: a multipart upload whose metadata
+// omits jobReference (as the Node.js client sends) must not panic.
+func TestUploadWithoutJobReference(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "dataset1"
+	)
+	ctx := context.Background()
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(
+		types.NewProject(projectID, types.NewDataset(datasetID)),
+	)); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+
+	jobJSON := `{"configuration":{"load":{"sourceFormat":"CSV","autodetect":true,` +
+		`"destinationTable":{"projectId":"test","datasetId":"dataset1","tableId":"uploaded"}}}}`
+	contentType, body := multipartUpload(jobJSON, "x,y\r\n1,a\r\n2,b")
+	code, resp := httpJSON(t, http.MethodPost,
+		testServer.URL+"/upload/bigquery/v2/projects/test/jobs?uploadType=multipart",
+		body, map[string]string{"Content-Type": contentType})
+	if code != http.StatusOK {
+		t.Fatalf("upload without jobReference: expected 200, got %d (%v)", code, resp)
+	}
+
+	code, resp = httpJSON(t, http.MethodPost,
+		testServer.URL+"/projects/test/queries",
+		`{"query":"SELECT COUNT(*) FROM dataset1.uploaded","useLegacySql":false}`, nil)
+	if code != http.StatusOK {
+		t.Fatalf("query uploaded table: %d (%v)", code, resp)
+	}
+	if rows := queryRows(t, resp); len(rows) != 1 || rows[0][0] != "2" {
+		t.Fatalf("expected 2 uploaded rows, got %v", rows)
+	}
+}
+
+// TestUploadToMissingDataset covers #396: uploading to a non-existent dataset
+// must return a clean error instead of panicking the process.
+func TestUploadToMissingDataset(t *testing.T) {
+	const projectID = "test"
+	ctx := context.Background()
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(
+		types.NewProject(projectID, types.NewDataset("dataset1")),
+	)); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+
+	jobJSON := `{"configuration":{"load":{"sourceFormat":"CSV","autodetect":true,` +
+		`"destinationTable":{"projectId":"test","datasetId":"missing","tableId":"t"}}}}`
+	contentType, body := multipartUpload(jobJSON, "x\r\n1")
+	code, resp := httpJSON(t, http.MethodPost,
+		testServer.URL+"/upload/bigquery/v2/projects/test/jobs?uploadType=multipart",
+		body, map[string]string{"Content-Type": contentType})
+	if code == http.StatusOK {
+		t.Fatalf("upload to a missing dataset should fail, got 200")
+	}
+	if resp["error"] == nil {
+		t.Fatalf("expected a structured error, got %v", resp)
+	}
+
+	// The server must still be responsive (it did not crash).
+	if c, _ := httpJSON(t, http.MethodGet,
+		testServer.URL+"/projects/test/datasets", "", nil); c != http.StatusOK {
+		t.Fatalf("server is not responsive after a failed upload: %d", c)
+	}
+}
+
+// TestExternalTable covers #392: an external table must be registered with the
+// query engine so that it can be queried after creation.
+func TestExternalTable(t *testing.T) {
+	const (
+		projectID  = "test"
+		datasetID  = "dataset1"
+		tableID    = "ext1"
+		bucketName = "ext-bucket"
+		objectName = "people.csv"
+		publicHost = "127.0.0.1"
+	)
+	ctx := context.Background()
+
+	storageServer, err := fakestorage.NewServerWithOptions(fakestorage.Options{
+		InitialObjects: []fakestorage.Object{
+			{
+				ObjectAttrs: fakestorage.ObjectAttrs{BucketName: bucketName, Name: objectName},
+				Content:     []byte("id,name\n1,Alice\n2,Bob\n3,Carol\n"),
+			},
+		},
+		PublicHost: publicHost,
+		Scheme:     "http",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer storageServer.Stop()
+	u, err := url.Parse(storageServer.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("STORAGE_EMULATOR_HOST", fmt.Sprintf("http://%s:%s", publicHost, u.Port()))
+
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(
+		types.NewProject(projectID, types.NewDataset(datasetID)),
+	)); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+	client, err := bigquery.NewClient(ctx, projectID,
+		option.WithEndpoint(testServer.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	table := client.Dataset(datasetID).Table(tableID)
+	if err := table.Create(ctx, &bigquery.TableMetadata{
+		ExternalDataConfig: &bigquery.ExternalDataConfig{
+			SourceFormat: bigquery.CSV,
+			SourceURIs:   []string{fmt.Sprintf("gs://%s/%s", bucketName, objectName)},
+			AutoDetect:   true,
+		},
+	}); err != nil {
+		t.Fatalf("create external table: %+v", err)
+	}
+
+	it, err := client.Query(
+		fmt.Sprintf("SELECT id, name FROM %s.%s ORDER BY id", datasetID, tableID),
+	).Read(ctx)
+	if err != nil {
+		t.Fatalf("query external table: %+v", err)
+	}
+	var got [][]bigquery.Value
+	for {
+		var row []bigquery.Value
+		if err := it.Next(&row); err == iterator.Done {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, row)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 rows from the external table, got %d: %v", len(got), got)
+	}
+
+	md, err := table.Metadata(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if md.ExternalDataConfig == nil {
+		t.Fatal("external data configuration did not round-trip on tables.get")
+	}
+}
+
+// TestServeListenCallback covers #333: the bound listener addresses must be
+// reported to the caller (so a requested port of 0 resolves to the real
+// port). The library reports them through SetListenCallback instead of
+// writing to stdout.
+func TestServeListenCallback(t *testing.T) {
+	ctx := context.Background()
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.SetProject("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	addrCh := make(chan [2]string, 1)
+	bqServer.SetListenCallback(func(httpAddr, grpcAddr string) {
+		addrCh <- [2]string{httpAddr, grpcAddr}
+	})
+	go func() { _ = bqServer.Serve(ctx, "127.0.0.1:0", "127.0.0.1:0") }()
+	defer bqServer.Stop(ctx)
+
+	var addrs [2]string
+	select {
+	case addrs = <-addrCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("listen callback was not invoked")
+	}
+	for i, name := range []string{"http", "grpc"} {
+		if addrs[i] == "" || strings.HasSuffix(addrs[i], ":0") {
+			t.Errorf("%s callback reported an unbound address: %q", name, addrs[i])
+			continue
+		}
+		conn, err := net.Dial("tcp", addrs[i])
+		if err != nil {
+			t.Errorf("%s address %q is not connectable: %v", name, addrs[i], err)
+			continue
+		}
+		conn.Close()
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -551,6 +551,16 @@ func parseDatetime(v string) (time.Time, error) {
 }
 
 func normalizeData(v interface{}, field *bigqueryv2.TableFieldSchema) (interface{}, error) {
+	// Without a schema field there is nothing to normalize against; this also
+	// guards the STRUCT branch below from recursing with a nil field.
+	if field == nil {
+		return v, nil
+	}
+	// A JSON column holds an arbitrary JSON document and must not be walked as
+	// a STRUCT/ARRAY even when its value is a map or slice.
+	if Type(field.Type) == JSON {
+		return v, nil
+	}
 	rv := reflect.ValueOf(v)
 	kind := rv.Kind()
 	if Mode(field.Mode) == RepeatedMode {


### PR DESCRIPTION
## Summary

Hands-on verification of the **v0.7.0** release surfaced a set of defects in the REST layer and in the startup / metadata handling. This PR fixes all of them. Each fix was reproduced against a locally running emulator before and after, and is covered by a new regression test.

## Fixes

| Issue(s) | Problem | Fix |
|---|---|---|
| #333 | `--port=0` logged `:0` instead of the assigned port | The server reports the bound HTTP/gRPC addresses via a `SetListenCallback` hook; the CLI prints them and the library writes nothing to stdout |
| #237 / #397 / #207 | Restarting against a persisted database crashed with a UNIQUE constraint violation, and overwrote the project so datasets disappeared from the REST catalog | The startup loader reconciles source-described objects with what is already stored, inserting only what is missing |
| #136 / #396 | An upload omitting `jobReference` (Node.js client) dereferenced a nil pointer; uploading to a missing dataset panicked | The upload job is normalized (a job id is generated when absent); a missing dataset returns 404 |
| #339 / #249 | `tables.get` did not populate `numRows` | `numRows` is filled from the backing table row count |
| #293 / #363 / #362 / #412 | `tables.patch` ignored the request body and echoed it back; `tables.update` was an `unsupported` stub; `X-HTTP-Method-Override` was not honored | Patch shallow-merges and persists, update replaces, both return the full resource, and a method-override wrapper runs before routing |
| #144 | Inserting into a JSON column stored a string double-encoded and panicked on a native JSON object | JSON columns are inserted via `PARSE_JSON`; `normalizeData` no longer walks a JSON value as a STRUCT |
| #347 | A load from `gs://` failed with "could not find default credentials" when no GCS emulator was configured | The Storage client falls back to anonymous access (honoring `GOOGLE_APPLICATION_CREDENTIALS` when set) |
| #392 | External tables were created in metadata but never registered with the query engine ("Table not found") | External table source data is materialized into a backing table through the load pipeline at creation time |

## Testing

- Regression tests for every fix were added to `server/server_test.go` (and `server/gcs_internal_test.go` for the unexported GCS options helper).
- `go test ./...` — full suite green, including the `test/e2e` multi-client conformance suite (Python, Ruby, PHP, Node.js, Java, `bq` CLI).
- `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

