### PR TITLE
Improve README intro for first-time visitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The only open-source emulator for Google BigQuery — run a BigQuery-compatible 
 # Quick start
 
 ```console
-$ docker run -it ghcr.io/goccy/bigquery-emulator:latest --project=test
+$ docker run -it -p 9050:9050 -p 9060:9060 ghcr.io/goccy/bigquery-emulator:latest --project=test
 $ bq --api http://0.0.0.0:9050 query --project_id=test "SELECT 1"
 ```
 
@@ -123,7 +123,7 @@ $ ./bigquery-emulator --project=test
 If you want to use docker image to start emulator, specify like the following.
 
 ```console
-$ docker run -it ghcr.io/goccy/bigquery-emulator:latest --project=test
+$ docker run -it -p 9050:9050 -p 9060:9060 ghcr.io/goccy/bigquery-emulator:latest --project=test
 ```
 
 * If you are using an M1 Mac ( and Docker Desktop ) you may get a warning. In that case please use `--platform linux/x86_64` option.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,19 @@
 
 [![build and test](https://github.com/goccy/bigquery-emulator/actions/workflows/test.yml/badge.svg)](https://github.com/goccy/bigquery-emulator/actions/workflows/test.yml)
 [![GoDoc](https://godoc.org/github.com/goccy/bigquery-emulator?status.svg)](https://pkg.go.dev/github.com/goccy/bigquery-emulator?tab=doc)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-db61a2)](https://github.com/sponsors/goccy)
 
 
-BigQuery emulator server implemented in Go.  
-BigQuery emulator provides a way to launch a BigQuery server on your local machine for testing and development.
+The only open-source emulator for Google BigQuery — run a BigQuery-compatible server on your local machine for testing and development, with no cloud project or credentials required.
+
+# Quick start
+
+```console
+$ docker run -it ghcr.io/goccy/bigquery-emulator:latest --project=test
+$ bq --api http://0.0.0.0:9050 query --project_id=test "SELECT 1"
+```
+
+See [Install](#install) for `go install`, prebuilt binaries and packages, and [How to start the standalone server](#how-to-start-the-standalone-server) for the full set of options and client examples.
 
 # Features
 
@@ -303,7 +312,7 @@ If you have specified a database file when starting `bigquery-emulator`, the fil
 
 ## BigQuery Emulator Architecture Overview
 
-After receiving a GoogleSQL query via the REST API from bq or a client SDK, the googlesqlite driver parses and analyzes the query and executes it against an embedded SQLite database.
+After receiving a GoogleSQL query via the REST API from bq or a client SDK, the googlesqlite driver parses and analyzes the query — using [go-googlesql](https://github.com/goccy/go-googlesql), a GoogleSQL (ZetaSQL) parser and analyzer written in Go — and executes it against an embedded SQLite database.
 
 <img width="600px" src="https://user-images.githubusercontent.com/209884/196145011-e35c2df4-5f5d-43ce-b7df-08cd130b5d31.png"></img>
 


### PR DESCRIPTION
## Summary

Reworks the top of the README so a visitor — particularly one arriving from an external link such as Hacker News — can tell what the project is and try it out within seconds.

- **Tagline** — replace the flat opening lines with a single sentence that leads with what makes the project unique (the only open-source BigQuery emulator) and the pain it removes (no cloud project or credentials required).
- **Sponsor badge** — add a Sponsor badge next to the existing build/GoDoc badges, giving a visible entry point to GitHub Sponsors from the top of the page.
- **Quick start** — add a copy-pasteable two-line `docker run` / `bq query` snippet before "Features", with links down to the full Install and standalone-server sections.
- **go-googlesql mention** — reference [go-googlesql](https://github.com/goccy/go-googlesql) in the architecture overview so the GoogleSQL frontend powering query execution is discoverable.

Content-only change to `README.md`; no code or behavior changes.

## Follow-up (not in this PR)

A demo GIF / asciinema recording near the top would further help conversion, but that is an asset that needs to be produced separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)