### PR TITLE
Fix Storage API issues: nil ReadOptions panic, case-insensitive columns, proto wrapper unwrap (#382, #380, #364)

### DIFF
--- a/server/storage_handler.go
+++ b/server/storage_handler.go
@@ -102,8 +102,18 @@ func (s *storageReadServer) CreateReadSession(ctx context.Context, req *storagep
 		TableModifiers:             req.ReadSession.TableModifiers,
 		TraceId:                    req.ReadSession.TraceId,
 	}
-	outputColumns := req.ReadSession.ReadOptions.SelectedFields
-	condition := req.ReadSession.ReadOptions.RowRestriction
+	// ReadOptions is optional: a client may create a read session
+	// without selected fields or a row restriction to read the whole
+	// table. Guard the dereference so an absent ReadOptions reads
+	// every column with no filter instead of panicking.
+	var (
+		outputColumns []string
+		condition     string
+	)
+	if readOptions := req.ReadSession.ReadOptions; readOptions != nil {
+		outputColumns = readOptions.SelectedFields
+		condition = readOptions.RowRestriction
+	}
 	outputColumnMap := map[string]struct{}{}
 	for _, outputColumn := range outputColumns {
 		outputColumnMap[outputColumn] = struct{}{}

--- a/server/storage_handler.go
+++ b/server/storage_handler.go
@@ -650,6 +650,13 @@ func (s *storageWriteServer) decodeProtoReflectValueFromKind(kind protoreflect.K
 		return v.Bytes(), nil
 	case protoreflect.MessageKind:
 		msg := v.Message()
+		// A google.protobuf scalar wrapper (wrappers.proto) carries a
+		// single `value` field; BigQuery maps a wrapper-typed proto
+		// field to its underlying scalar column, so unwrap it rather
+		// than rendering a one-field STRUCT.
+		if scalar, ok, err := s.unwrapWrapperValue(msg); ok || err != nil {
+			return scalar, err
+		}
 		structV := map[string]interface{}{}
 		var decodeErr error
 		msg.Range(func(f protoreflect.FieldDescriptor, val protoreflect.Value) bool {
@@ -666,6 +673,37 @@ func (s *storageWriteServer) decodeProtoReflectValueFromKind(kind protoreflect.K
 		return nil, fmt.Errorf("unsupported group kind for storage api")
 	}
 	return nil, fmt.Errorf("specified unknown kind")
+}
+
+// wrapperMessageNames is the set of google.protobuf scalar wrapper messages
+// (wrappers.proto). Each carries a single scalar `value` field.
+var wrapperMessageNames = map[protoreflect.FullName]struct{}{
+	"google.protobuf.DoubleValue": {},
+	"google.protobuf.FloatValue":  {},
+	"google.protobuf.Int64Value":  {},
+	"google.protobuf.UInt64Value": {},
+	"google.protobuf.Int32Value":  {},
+	"google.protobuf.UInt32Value": {},
+	"google.protobuf.BoolValue":   {},
+	"google.protobuf.StringValue": {},
+	"google.protobuf.BytesValue":  {},
+}
+
+// unwrapWrapperValue reports whether msg is a google.protobuf scalar wrapper
+// and, if so, returns its underlying `value`. A wrapper-typed proto field
+// maps to its scalar BigQuery column, so the Storage Write API decoder must
+// hand back the bare scalar instead of a single-field STRUCT, which the
+// schema-driven normalizer cannot reconcile with a scalar column.
+func (s *storageWriteServer) unwrapWrapperValue(msg protoreflect.Message) (interface{}, bool, error) {
+	if _, ok := wrapperMessageNames[msg.Descriptor().FullName()]; !ok {
+		return nil, false, nil
+	}
+	valueField := msg.Descriptor().Fields().ByName("value")
+	if valueField == nil {
+		return nil, false, nil
+	}
+	v, err := s.decodeProtoReflectValueFromKind(valueField.Kind(), msg.Get(valueField))
+	return v, true, err
 }
 
 func (s *storageWriteServer) insertTableData(ctx context.Context, tx *connection.Tx, status *writeStreamStatus, data types.Data) error {

--- a/server/storage_internal_test.go
+++ b/server/storage_internal_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// TestDecodeProtoWrapperValues is a regression test for
+// https://github.com/goccy/bigquery-emulator/issues/364: a Storage Write API
+// proto field of a google.protobuf wrapper type (wrappers.proto) was decoded
+// as a one-field STRUCT (`{"value": x}`) instead of the bare scalar `x`. The
+// schema-driven normalizer cannot reconcile a STRUCT with the scalar column a
+// wrapper type maps to, so the write failed.
+func TestDecodeProtoWrapperValues(t *testing.T) {
+	s := &storageWriteServer{}
+	cases := []struct {
+		name string
+		msg  protoreflect.ProtoMessage
+		want interface{}
+	}{
+		{"DoubleValue", wrapperspb.Double(1.5), 1.5},
+		{"FloatValue", wrapperspb.Float(2.5), 2.5},
+		{"Int64Value", wrapperspb.Int64(7), int64(7)},
+		{"Int32Value", wrapperspb.Int32(8), int64(8)},
+		{"UInt64Value", wrapperspb.UInt64(9), uint64(9)},
+		{"UInt32Value", wrapperspb.UInt32(10), uint64(10)},
+		{"BoolValue", wrapperspb.Bool(true), true},
+		{"StringValue", wrapperspb.String("hi"), "hi"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := protoreflect.ValueOfMessage(tc.msg.ProtoReflect())
+			got, err := s.decodeProtoReflectValueFromKind(protoreflect.MessageKind, v)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("decoded %T(%v); want %T(%v) — wrapper was not unwrapped",
+					got, got, tc.want, tc.want)
+			}
+		})
+	}
+
+	// BytesValue unwraps to a []byte, compared separately.
+	t.Run("BytesValue", func(t *testing.T) {
+		v := protoreflect.ValueOfMessage(wrapperspb.Bytes([]byte("ab")).ProtoReflect())
+		got, err := s.decodeProtoReflectValueFromKind(protoreflect.MessageKind, v)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		b, ok := got.([]byte)
+		if !ok || string(b) != "ab" {
+			t.Fatalf("decoded %T(%v); want []byte(\"ab\")", got, got)
+		}
+	})
+}

--- a/server/storage_test.go
+++ b/server/storage_test.go
@@ -745,3 +745,82 @@ func generateExampleMessages(numMessages int) ([][]byte, error) {
 	}
 	return msgs, nil
 }
+
+// TestIssue382CreateReadSessionWithoutReadOptions is a regression test for
+// https://github.com/goccy/bigquery-emulator/issues/382: CreateReadSession
+// panicked with a nil pointer dereference when the request's ReadSession
+// carried no ReadOptions (a valid request shape — read the whole table with
+// no column projection or row restriction).
+func TestIssue382CreateReadSessionWithoutReadOptions(t *testing.T) {
+	const (
+		project = "test"
+		dataset = "dataset1"
+		table   = "table_a"
+	)
+	ctx := context.Background()
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.YAMLSource(filepath.Join("testdata", "data.yaml"))); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Close()
+	}()
+	opts, err := testServer.GRPCClientOptions(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bqReadClient, err := bqStorage.NewBigQueryReadClient(ctx, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bqReadClient.Close()
+
+	// ReadSession deliberately carries no ReadOptions.
+	req := &storagepb.CreateReadSessionRequest{
+		Parent: fmt.Sprintf("projects/%s", project),
+		ReadSession: &storagepb.ReadSession{
+			Table: fmt.Sprintf("projects/%s/datasets/%s/tables/%s",
+				project, dataset, table),
+			DataFormat: storagepb.DataFormat_AVRO,
+		},
+		MaxStreamCount: 1,
+	}
+	session, err := bqReadClient.CreateReadSession(ctx, req, rpcOpts)
+	if err != nil {
+		t.Fatalf("CreateReadSession without ReadOptions: %v", err)
+	}
+	if len(session.GetStreams()) == 0 {
+		t.Fatal("expected at least one stream in the session")
+	}
+	if session.GetAvroSchema().GetSchema() == "" {
+		t.Fatal("expected an AVRO schema on the session")
+	}
+
+	// The session must still be readable end to end: with no selected
+	// fields the whole row is streamed back.
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	ch := make(chan *storagepb.ReadRowsResponse)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		defer close(ch)
+		if err := processStream(t, streamCtx, bqReadClient, session.GetStreams()[0].Name, ch); err != nil {
+			t.Errorf("processStream failure: %v", err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		if err := processAvro(t, streamCtx, session.GetAvroSchema().GetSchema(), ch); err != nil {
+			t.Errorf("error processing AVRO: %v", err)
+		}
+	}()
+	wg.Wait()
+}

--- a/types/types.go
+++ b/types/types.go
@@ -474,14 +474,18 @@ func NewTableWithSchema(t *bigqueryv2.Table, data Data) (*Table, error) {
 	columns := make([]*Column, 0, len(t.Schema.Fields))
 	nameToFieldMap := map[string]*bigqueryv2.TableFieldSchema{}
 	for _, field := range t.Schema.Fields {
-		nameToFieldMap[field.Name] = field
+		// BigQuery column names are case-insensitive; index by a
+		// lower-cased key so a row keyed with a different case (e.g. a
+		// Storage Write API proto field declared `createdat` against a
+		// `createdAt` column) still resolves to its column.
+		nameToFieldMap[strings.ToLower(field.Name)] = field
 		columns = append(columns, NewColumnWithSchema(field))
 	}
 	newData := Data{}
 	for _, row := range data {
 		rowData := map[string]interface{}{}
 		for k, v := range row {
-			field, exists := nameToFieldMap[k]
+			field, exists := nameToFieldMap[strings.ToLower(k)]
 			if !exists {
 				continue
 			}
@@ -489,7 +493,9 @@ func NewTableWithSchema(t *bigqueryv2.Table, data Data) (*Table, error) {
 			if err != nil {
 				return nil, err
 			}
-			rowData[k] = v
+			// Key the normalized row by the schema's canonical column
+			// name so downstream INSERT generation matches the column.
+			rowData[field.Name] = v
 		}
 		newData = append(newData, rowData)
 	}
@@ -580,17 +586,19 @@ func normalizeData(v interface{}, field *bigqueryv2.TableFieldSchema) (interface
 		return values, nil
 	}
 	if kind == reflect.Map {
+		// STRUCT field names, like top-level column names, are matched
+		// case-insensitively: index every map by a lower-cased key.
 		fieldMap := map[string]*bigqueryv2.TableFieldSchema{}
 		columnNameToValueMap := map[string]interface{}{}
 		for _, f := range field.Fields {
-			fieldMap[f.Name] = f
-			columnNameToValueMap[f.Name] = nil
+			fieldMap[strings.ToLower(f.Name)] = f
+			columnNameToValueMap[strings.ToLower(f.Name)] = nil
 		}
 		for _, key := range rv.MapKeys() {
 			if key.Kind() != reflect.String {
 				return nil, fmt.Errorf("invalid value type %s for STRUCT column", key.Kind())
 			}
-			columnName := key.Interface().(string)
+			columnName := strings.ToLower(key.Interface().(string))
 			value, err := normalizeData(rv.MapIndex(key).Interface(), fieldMap[columnName])
 			if err != nil {
 				return nil, err
@@ -599,7 +607,7 @@ func normalizeData(v interface{}, field *bigqueryv2.TableFieldSchema) (interface
 		}
 		fields := make([]map[string]interface{}, 0, len(fieldMap))
 		for _, f := range field.Fields {
-			value, exists := columnNameToValueMap[f.Name]
+			value, exists := columnNameToValueMap[strings.ToLower(f.Name)]
 			if !exists {
 				return nil, fmt.Errorf("failed to find value from %v by %s", columnNameToValueMap, f.Name)
 			}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,56 @@
+package types
+
+import (
+	"testing"
+
+	bigqueryv2 "google.golang.org/api/bigquery/v2"
+)
+
+// TestNewTableWithSchemaCaseInsensitiveColumns is a regression test for
+// https://github.com/goccy/bigquery-emulator/issues/380: a row keyed with a
+// different letter case than the table schema (e.g. a Storage Write API proto
+// field `createdat` against a `createdAt` column) had its value silently
+// dropped. BigQuery column names are case-insensitive.
+func TestNewTableWithSchemaCaseInsensitiveColumns(t *testing.T) {
+	table := &bigqueryv2.Table{
+		TableReference: &bigqueryv2.TableReference{TableId: "t"},
+		Schema: &bigqueryv2.TableSchema{
+			Fields: []*bigqueryv2.TableFieldSchema{
+				{Name: "createdAt", Type: "STRING"},
+				{Name: "Info", Type: "RECORD", Fields: []*bigqueryv2.TableFieldSchema{
+					{Name: "userName", Type: "STRING"},
+				}},
+			},
+		},
+	}
+	// Every key differs in case from its schema column.
+	data := Data{
+		{
+			"createdat": "2024-01-01",
+			"info":      map[string]interface{}{"username": "alice"},
+		},
+	}
+	got, err := NewTableWithSchema(table, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Data) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(got.Data))
+	}
+	row := got.Data[0]
+
+	// The scalar value must survive under the schema's canonical name.
+	if row["createdAt"] != "2024-01-01" {
+		t.Errorf("createdAt = %v; want \"2024-01-01\"", row["createdAt"])
+	}
+
+	// The nested STRUCT field must likewise resolve case-insensitively.
+	// normalizeData renders a STRUCT as a slice of single-key maps.
+	info, ok := row["Info"].([]map[string]interface{})
+	if !ok || len(info) != 1 {
+		t.Fatalf("Info = %#v; want one STRUCT field", row["Info"])
+	}
+	if info[0]["userName"] != "alice" {
+		t.Errorf("Info.userName = %v; want \"alice\"", info[0]["userName"])
+	}
+}


### PR DESCRIPTION
## Summary

Three Storage API defects, all in adjacent code, fixed together. Two of them (#380 and #364) no longer panic since the #467 `normalizeData` rewrite, but the underlying behaviour — silently dropping case-mismatched columns and mangling proto wrapper values — was still wrong.

| Issue | Symptom | Fix |
|---|---|---|
| **#382** | `CreateReadSession` panics with a nil pointer when the request's `ReadSession` carries no `ReadOptions` (a valid request shape — Java client without `setReadOptions`). | `server/storage_handler.go` — guard the `ReadOptions` dereference; an absent `ReadOptions` reads every column with no filter. |
| **#380** | A Storage Write API row whose proto field name differs in case from the column (e.g. `createdat` vs `createdAt`) had its value silently dropped. BigQuery column names are case-insensitive. | `types/types.go` — index `NewTableWithSchema` and `normalizeData`'s STRUCT branch by a lower-cased key; store the normalized value under the schema's canonical name. |
| **#364** | A Storage Write API proto field of a `google.protobuf` wrapper type (`DoubleValue`, `Int64Value`, ...) was decoded as a one-field STRUCT (`{"value": x}`). BigQuery maps a wrapper-typed field to its scalar column, so the schema-driven normalizer could not reconcile the two and the append failed. | `server/storage_handler.go` — recognise the nine scalar wrapper messages from `wrappers.proto` and unwrap each to its bare `value`. |

## Testing

- `server/storage_test.go` — `TestIssue382CreateReadSessionWithoutReadOptions` opens a read session with no `ReadOptions` and reads it end to end.
- `types/types_test.go` — `TestNewTableWithSchemaCaseInsensitiveColumns` covers case-insensitive top-level and STRUCT field matching.
- `server/storage_internal_test.go` — `TestDecodeProtoWrapperValues` covers all nine wrapper types (`Double`/`Float`/`Int64`/`Int32`/`UInt64`/`UInt32`/`Bool`/`String`/`Bytes`).
- `go test ./server/... ./types/...` — full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
