### PR TITLE
Fix IN UNNEST(@param) with named ARRAY/STRUCT parameters silently returning no rows

### DIFF
--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -190,7 +190,7 @@ func (r *Repository) Query(ctx context.Context, tx *connection.Tx, projectID, da
 
 	values := []interface{}{}
 	for _, param := range params {
-		value, err := r.queryParameterValueToGoValue(param.ParameterValue)
+		value, err := r.queryParameterValueToGoValue(param.ParameterType, param.ParameterValue)
 		if err != nil {
 			return nil, err
 		}
@@ -299,6 +299,28 @@ func (r *Repository) Query(ctx context.Context, tx *connection.Tx, projectID, da
 	}, nil
 }
 
+// emptyTypedArray returns a typed empty Go slice for the given BigQuery array
+// element type. Using a typed slice (e.g. []string{}) rather than
+// []interface{}{} lets googlesqlite infer the correct ARRAY<T> declaration
+// even when there are no elements to reflect on.
+func emptyTypedArray(arrayType *bigqueryv2.QueryParameterType) interface{} {
+	if arrayType == nil {
+		return []interface{}{}
+	}
+	switch strings.ToUpper(arrayType.Type) {
+	case "STRING", "BYTES":
+		return []string{}
+	case "INT64", "INTEGER", "INT":
+		return []int64{}
+	case "FLOAT64", "FLOAT", "DOUBLE":
+		return []float64{}
+	case "BOOL", "BOOLEAN":
+		return []bool{}
+	default:
+		return []interface{}{}
+	}
+}
+
 // coerceScalarParameterValue converts the JSON-string representation
 // of a scalar query parameter into the Go type that matches the
 // declared BigQuery parameter type. Returns the original value
@@ -366,17 +388,55 @@ func coerceScalarParameterValue(value interface{}, paramType string) interface{}
 	return value
 }
 
-func (r *Repository) queryParameterValueToGoValue(value *bigqueryv2.QueryParameterValue) (interface{}, error) {
+func (r *Repository) queryParameterValueToGoValue(ptype *bigqueryv2.QueryParameterType, value *bigqueryv2.QueryParameterValue) (interface{}, error) {
 	// A nil parameter value denotes an explicit NULL: the handler clears it
 	// when the request JSON carried `null` (or no value) for the parameter.
 	if value == nil {
 		return nil, nil
 	}
+	// When the declared type is known, use it as the primary signal. This
+	// handles the empty-array and empty-struct cases where ArrayValues /
+	// StructValues are nil due to JSON omitempty on the bigqueryv2 fields.
+	if ptype != nil {
+		switch strings.ToUpper(ptype.Type) {
+		case "ARRAY":
+			if len(value.ArrayValues) == 0 {
+				return emptyTypedArray(ptype.ArrayType), nil
+			}
+			arr := make([]interface{}, 0, len(value.ArrayValues))
+			for _, v := range value.ArrayValues {
+				elem, err := r.queryParameterValueToGoValue(ptype.ArrayType, v)
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, elem)
+			}
+			return arr, nil
+		case "STRUCT":
+			fieldTypes := make(map[string]*bigqueryv2.QueryParameterType, len(ptype.StructTypes))
+			for _, ft := range ptype.StructTypes {
+				fieldTypes[ft.Name] = ft.Type
+			}
+			st := make(map[string]interface{}, len(value.StructValues))
+			for k, v := range value.StructValues {
+				vCopy := v
+				elem, err := r.queryParameterValueToGoValue(fieldTypes[k], &vCopy)
+				if err != nil {
+					return nil, err
+				}
+				st[k] = elem
+			}
+			return st, nil
+		}
+	}
+	// Scalar fallback: type is absent or is a scalar type. Fall back to
+	// data-driven detection for safety (e.g. recursive calls where ptype
+	// was not propagated).
 	switch {
 	case len(value.ArrayValues) != 0:
 		arr := make([]interface{}, 0, len(value.ArrayValues))
 		for _, v := range value.ArrayValues {
-			elem, err := r.queryParameterValueToGoValue(v)
+			elem, err := r.queryParameterValueToGoValue(nil, v)
 			if err != nil {
 				return nil, err
 			}
@@ -386,7 +446,8 @@ func (r *Repository) queryParameterValueToGoValue(value *bigqueryv2.QueryParamet
 	case len(value.StructValues) != 0:
 		st := make(map[string]interface{}, len(value.StructValues))
 		for k, v := range value.StructValues {
-			elem, err := r.queryParameterValueToGoValue(&v)
+			vCopy := v
+			elem, err := r.queryParameterValueToGoValue(nil, &vCopy)
 			if err != nil {
 				return nil, err
 			}

--- a/server/handler.go
+++ b/server/handler.go
@@ -666,35 +666,51 @@ func parseQueryValueAsUint64(r *http.Request, key string) (uint64, bool) {
 }
 
 // applyNullQueryParameters inspects the raw JSON of a query-parameters array
-// and clears the ParameterValue of every parameter whose value was JSON null
-// or absent. The bigqueryv2 structs store a parameter value as a plain string,
-// so they cannot otherwise distinguish a NULL parameter from an empty string.
+// and clears the ParameterValue of every scalar parameter whose value was JSON
+// null or absent. The bigqueryv2 structs store a parameter value as a plain
+// string, so they cannot otherwise distinguish a NULL scalar from an empty string.
 //
-// Array and struct parameters never carry a scalar "value" field; they use
-// "arrayValues" / "structValues" instead. We must not clear those.
+// ARRAY and STRUCT parameters must never be cleared, even when their
+// parameterValue is empty (e.g. an empty []string{} omits "arrayValues"
+// entirely due to JSON omitempty). The parameter type is used as the
+// authoritative signal: any parameter whose type is "ARRAY" or "STRUCT" is
+// left untouched.
 func applyNullQueryParameters(rawParams []json.RawMessage, params []*bigqueryv2.QueryParameter) {
 	for i, raw := range rawParams {
 		if i >= len(params) || params[i] == nil {
 			continue
 		}
 		var p struct {
-			ParameterValue *struct {
-				Value        *json.RawMessage          `json:"value"`
-				ArrayValues  []json.RawMessage         `json:"arrayValues"`
-				StructValues map[string]json.RawMessage `json:"structValues"`
-			} `json:"parameterValue"`
+			ParameterType *struct {
+				Type string `json:"type"`
+			} `json:"parameterType"`
+			ParameterValue *json.RawMessage `json:"parameterValue"`
 		}
 		if err := json.Unmarshal(raw, &p); err != nil {
 			continue
 		}
-		// Non-scalar parameters (ARRAY, STRUCT) carry no "value" field —
-		// only "arrayValues" or "structValues". Skip clearing those.
-		if p.ParameterValue != nil &&
-			(len(p.ParameterValue.ArrayValues) > 0 || len(p.ParameterValue.StructValues) > 0) {
+		// ARRAY and STRUCT parameters must not be cleared regardless of whether
+		// their parameterValue happens to be empty.
+		if p.ParameterType != nil {
+			switch p.ParameterType.Type {
+			case "ARRAY", "STRUCT":
+				continue
+			}
+		}
+		// No parameterValue key at all → treat as null scalar.
+		if p.ParameterValue == nil {
+			params[i].ParameterValue = nil
 			continue
 		}
-		if p.ParameterValue == nil || p.ParameterValue.Value == nil ||
-			string(*p.ParameterValue.Value) == "null" {
+		// Decode parameterValue into a key-presence map.
+		// JSON null decodes to a nil map; map lookups on nil return false safely.
+		var pv map[string]json.RawMessage
+		if err := json.Unmarshal(*p.ParameterValue, &pv); err != nil {
+			continue
+		}
+		// Scalar: clear if "value" is absent or is the JSON literal null.
+		valueRaw, hasValue := pv["value"]
+		if !hasValue || string(valueRaw) == "null" {
 			params[i].ParameterValue = nil
 		}
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -669,6 +669,9 @@ func parseQueryValueAsUint64(r *http.Request, key string) (uint64, bool) {
 // and clears the ParameterValue of every parameter whose value was JSON null
 // or absent. The bigqueryv2 structs store a parameter value as a plain string,
 // so they cannot otherwise distinguish a NULL parameter from an empty string.
+//
+// Array and struct parameters never carry a scalar "value" field; they use
+// "arrayValues" / "structValues" instead. We must not clear those.
 func applyNullQueryParameters(rawParams []json.RawMessage, params []*bigqueryv2.QueryParameter) {
 	for i, raw := range rawParams {
 		if i >= len(params) || params[i] == nil {
@@ -676,10 +679,18 @@ func applyNullQueryParameters(rawParams []json.RawMessage, params []*bigqueryv2.
 		}
 		var p struct {
 			ParameterValue *struct {
-				Value *json.RawMessage `json:"value"`
+				Value        *json.RawMessage          `json:"value"`
+				ArrayValues  []json.RawMessage         `json:"arrayValues"`
+				StructValues map[string]json.RawMessage `json:"structValues"`
 			} `json:"parameterValue"`
 		}
 		if err := json.Unmarshal(raw, &p); err != nil {
+			continue
+		}
+		// Non-scalar parameters (ARRAY, STRUCT) carry no "value" field —
+		// only "arrayValues" or "structValues". Skip clearing those.
+		if p.ParameterValue != nil &&
+			(len(p.ParameterValue.ArrayValues) > 0 || len(p.ParameterValue.StructValues) > 0) {
 			continue
 		}
 		if p.ParameterValue == nil || p.ParameterValue.Value == nil ||

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4108,12 +4108,12 @@ WHERE persona_id IN UNNEST(@ids)
 		}
 	})
 
-	// Empty array: IN UNNEST([]) must return no rows, not error.
-	t.Run("empty array returns no rows", func(t *testing.T) {
-		q := client.Query(`
-SELECT persona_id
-FROM dataset1.people
-WHERE persona_id IN UNNEST(@ids)`)
+	// Empty array: the empty array must be preserved (not silently cleared to
+	// NULL). ARRAY_LENGTH distinguishes the two: an empty []string{} gives 0,
+	// while NULL would give NULL. IN UNNEST([]) also returns no rows, but that
+	// assertion holds for either behaviour and would not catch a regression.
+	t.Run("empty array is preserved, not cleared to NULL", func(t *testing.T) {
+		q := client.Query(`SELECT ARRAY_LENGTH(@ids) AS n`)
 		q.Parameters = []bigquery.QueryParameter{
 			{Name: "ids", Value: []string{}},
 		}
@@ -4121,19 +4121,14 @@ WHERE persona_id IN UNNEST(@ids)`)
 		if err != nil {
 			t.Fatalf("empty array query failed: %v", err)
 		}
-		var count int
-		for {
-			var row []bigquery.Value
-			if err := it.Next(&row); err != nil {
-				if err == iterator.Done {
-					break
-				}
-				t.Fatal(err)
-			}
-			count++
+		var row struct{ N bigquery.NullInt64 }
+		if err := it.Next(&row); err != nil {
+			t.Fatal(err)
 		}
-		if count != 0 {
-			t.Errorf("got %d rows, want 0", count)
+		if !row.N.Valid {
+			t.Error("ARRAY_LENGTH of empty array returned NULL; want 0 (array was silently cleared)")
+		} else if row.N.Int64 != 0 {
+			t.Errorf("ARRAY_LENGTH of empty array = %d; want 0", row.N.Int64)
 		}
 	})
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4020,3 +4020,163 @@ func TestIssue468CountStarOverEmptyTable(t *testing.T) {
 		}
 	})
 }
+
+// TestInUnnestArrayParam is a regression test for a bug introduced in v0.7.0
+// where named ARRAY parameters were silently discarded before reaching the
+// query engine.  applyNullQueryParameters checked parameterValue.value == nil
+// to detect NULL scalars, but array parameters carry their data in
+// parameterValue.arrayValues — they never have a value field — so every array
+// parameter was incorrectly cleared to nil, causing IN UNNEST(@param) to
+// match nothing.  The fix skips clearing when arrayValues or structValues are
+// present in the raw JSON.
+func TestInUnnestArrayParam(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "dataset1"
+		tableID   = "people"
+	)
+	ctx := context.Background()
+
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(types.NewProject(
+		projectID,
+		types.NewDataset(
+			datasetID,
+			types.NewTable(
+				tableID,
+				[]*types.Column{
+					types.NewColumn("persona_id", types.STRING),
+					types.NewColumn("status", types.STRING),
+				},
+				types.Data{
+					{"persona_id": "persona-aaa", "status": "active"},
+					{"persona_id": "persona-bbb", "status": "suspended"},
+					{"persona_id": "persona-ccc", "status": "active"},
+				},
+			),
+		),
+	))); err != nil {
+		t.Fatal(err)
+	}
+
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Close()
+	}()
+
+	client, err := bigquery.NewClient(ctx, projectID,
+		option.WithEndpoint(testServer.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// Core case: ARRAY parameter must not be wiped by applyNullQueryParameters.
+	t.Run("string array matches correct rows", func(t *testing.T) {
+		q := client.Query(`
+SELECT persona_id
+FROM dataset1.people
+WHERE persona_id IN UNNEST(@ids)
+  AND status = 'active'`)
+		q.Parameters = []bigquery.QueryParameter{
+			{Name: "ids", Value: []string{"persona-aaa", "persona-bbb"}},
+		}
+		it, err := q.Read(ctx)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+		var got []string
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatal(err)
+			}
+			got = append(got, fmt.Sprint(row[0]))
+		}
+		// persona-bbb is suspended, persona-ccc is not in the list.
+		if len(got) != 1 || got[0] != "persona-aaa" {
+			t.Errorf("got %v, want [persona-aaa]", got)
+		}
+	})
+
+	// Empty array: IN UNNEST([]) must return no rows, not error.
+	t.Run("empty array returns no rows", func(t *testing.T) {
+		q := client.Query(`
+SELECT persona_id
+FROM dataset1.people
+WHERE persona_id IN UNNEST(@ids)`)
+		q.Parameters = []bigquery.QueryParameter{
+			{Name: "ids", Value: []string{}},
+		}
+		it, err := q.Read(ctx)
+		if err != nil {
+			t.Fatalf("empty array query failed: %v", err)
+		}
+		var count int
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatal(err)
+			}
+			count++
+		}
+		if count != 0 {
+			t.Errorf("got %d rows, want 0", count)
+		}
+	})
+
+	// STRUCT parameters also use structValues (not value) in the REST JSON and
+	// must survive applyNullQueryParameters for the same reason as arrays.
+	t.Run("struct param is not cleared", func(t *testing.T) {
+		type filter struct {
+			Status string
+		}
+		q := client.Query(`SELECT @f IS NULL AS is_null`)
+		q.Parameters = []bigquery.QueryParameter{
+			{Name: "f", Value: filter{Status: "active"}},
+		}
+		it, err := q.Read(ctx)
+		if err != nil {
+			t.Fatalf("struct param query failed: %v", err)
+		}
+		var row []bigquery.Value
+		if err := it.Next(&row); err != nil {
+			t.Fatal(err)
+		}
+		if row[0] != false {
+			t.Errorf("struct param was cleared: got is_null=%v, want false", row[0])
+		}
+	})
+
+	// Scalar NULL parameters must still be treated as NULL after the fix
+	// (i.e. applyNullQueryParameters must not have broken the scalar path).
+	t.Run("null scalar param still observed as NULL", func(t *testing.T) {
+		q := client.Query(`SELECT @p IS NULL AS is_null`)
+		q.Parameters = []bigquery.QueryParameter{
+			{Name: "p", Value: bigquery.NullString{}},
+		}
+		it, err := q.Read(ctx)
+		if err != nil {
+			t.Fatalf("null scalar query failed: %v", err)
+		}
+		var row []bigquery.Value
+		if err := it.Next(&row); err != nil {
+			t.Fatal(err)
+		}
+		if row[0] != true {
+			t.Errorf("null scalar: got is_null=%v, want true", row[0])
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`IN UNNEST(@param)` with a named ARRAY parameter returned 0 rows in v0.7.x (regression from v0.6.6).

### Root cause

`applyNullQueryParameters` was introduced in v0.7.0 to distinguish NULL scalar parameters from empty strings, because the `bigqueryv2` struct uses a plain `string` for parameter values and cannot natively represent `nil`. It detected NULL by checking whether the `"value"` field was absent or JSON null. However, **ARRAY and STRUCT parameters never carry a scalar `"value"` field** — they encode their data in `"arrayValues"` / `"structValues"` instead — so every ARRAY and STRUCT parameter was incorrectly cleared to `nil` before reaching the query engine.

A second related issue: an empty `[]string{}` parameter has `arrayValues` omitted from the JSON body entirely (`omitempty` on the `bigqueryv2` field), so even after preserving the `ParameterValue`, `queryParameterValueToGoValue` fell through to the scalar path and returned `""` — causing googlesqlite to see a STRING instead of an empty `ARRAY<STRING>`.

### Fix

**`server/handler.go` — `applyNullQueryParameters`**

Uses `parameterType.type` as the primary guard: any parameter declared as `ARRAY` or `STRUCT` is skipped entirely. For scalar parameters, decodes `parameterValue` into a key-presence map and clears only when the `"value"` key is absent or is the JSON literal `null`.

**`internal/contentdata/repository.go` — `queryParameterValueToGoValue`**

Refactored to accept `ptype *QueryParameterType` as its first parameter, so type information drives conversion rather than being patched in by the caller. When `ptype.Type == "ARRAY"` and `ArrayValues` is empty, returns a typed Go slice (e.g. `[]string{}`) via `emptyTypedArray` so googlesqlite can infer the correct `ARRAY<T>` element type from reflection. Type information is propagated through recursive ARRAY/STRUCT calls via `ptype.ArrayType` and the `ptype.StructTypes` field map.

## Test

`TestInUnnestArrayParam` in `server/server_test.go` covers:
- String array filtering via `IN UNNEST(@param)` (primary regression case)
- Empty array preserved as a real empty array, not cleared to NULL — asserted via `ARRAY_LENGTH(@ids) = 0` (stronger than row-count, which passes for either behaviour)
- STRUCT parameter is not cleared (`@f IS NULL` → `false`)
- NULL scalar parameter is still correctly observed as NULL (regression guard for the original fix)

## Test plan

- [ ] `go test ./server/... -run TestInUnnestArrayParam` passes
- [ ] Full test suite passes: `go test ./server/... ./internal/... ./types/...`
- [ ] Verify downstream: queries using `IN UNNEST(@namedArrayParam)` return correct results