### PR TITLE
Register the job in the synchronous jobs.query path (fix 404 + RequestId collision)

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -2027,7 +2027,8 @@ func (h *jobsQueryHandler) Handle(ctx context.Context, r *jobsQueryRequest) (*in
 		return nil, err
 	}
 	defer tx.RollbackIfNotCommitted()
-	response, err := r.server.contentRepo.Query(
+	startTime := time.Now()
+	response, queryErr := r.server.contentRepo.Query(
 		ctx,
 		tx,
 		r.project.ID,
@@ -2035,10 +2036,87 @@ func (h *jobsQueryHandler) Handle(ctx context.Context, r *jobsQueryRequest) (*in
 		r.queryRequest.Query,
 		r.queryRequest.QueryParameters,
 	)
-	if err != nil {
-		return nil, err
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	endTime := time.Now()
+	// jobs.query allocates jobIDs server-side (real BigQuery does the
+	// same). queryRequest.RequestId is the *idempotency* key — same
+	// RequestId on retry should return the cached result — and is
+	// deliberately not the jobID. The Go BigQuery client in particular
+	// instantiates a fresh `uid.NewSpace("request", …)` per call, so its
+	// per-Space atomic counter always emits `-0001`; concurrent
+	// in-process callers therefore submit identical RequestIds and would
+	// collide on AddJob if we routed them through as the jobID. Idempotency
+	// (RequestId → cached response) is a TODO; for now every call gets a
+	// fresh jobID.
+	jobID := randomID()
+
+	// Persist the job in the metadata store, mirroring what
+	// jobsInsertHandler.Handle does at line ~1758. The previous behaviour
+	// returned a JobReference whose ID was never recorded, so any client
+	// that then issued `jobs.get(jobID)` — e.g. Go's
+	// `RowIterator.SourceJob().Status(ctx)`, or the Java/Node clients
+	// that poll the job for status after a synchronous query — got a 404
+	// and (for clients that treat 404 as transient) hung re-polling. The
+	// synthetic Job below carries the minimum fields the GET handler
+	// returns to the caller; DryRun queries skip both the AddJob and the
+	// Commit so they remain side-effect-free.
+	var totalBytes int64
+	if response != nil {
+		totalBytes = response.TotalBytes
+	}
+	job := &bigqueryv2.Job{
+		Kind: "bigquery#job",
+		JobReference: &bigqueryv2.JobReference{
+			ProjectId: r.project.ID,
+			JobId:     jobID,
+			Location:  r.queryRequest.Location,
+		},
+		Configuration: &bigqueryv2.JobConfiguration{
+			JobType: "QUERY",
+			DryRun:  r.queryRequest.DryRun,
+			Query: &bigqueryv2.JobConfigurationQuery{
+				Query:           r.queryRequest.Query,
+				QueryParameters: r.queryRequest.QueryParameters,
+				Priority:        "INTERACTIVE",
+			},
+		},
+		Status: &bigqueryv2.JobStatus{State: "DONE"},
+		Statistics: &bigqueryv2.JobStatistics{
+			Query: &bigqueryv2.JobStatistics2{
+				CacheHit:            false,
+				StatementType:       "SELECT",
+				TotalBytesBilled:    totalBytes,
+				TotalBytesProcessed: totalBytes,
+			},
+			CreationTime:        startTime.Unix(),
+			StartTime:           startTime.Unix(),
+			EndTime:             endTime.Unix(),
+			TotalBytesProcessed: totalBytes,
+		},
+		SelfLink: fmt.Sprintf(
+			"http://%s/bigquery/v2/projects/%s/jobs/%s",
+			r.server.httpServer.Addr,
+			r.project.ID,
+			jobID,
+		),
 	}
 	if !r.queryRequest.DryRun {
+		if err := r.project.AddJob(
+			ctx,
+			tx.Tx(),
+			metadata.NewJob(
+				r.server.metaRepo,
+				r.project.ID,
+				jobID,
+				job,
+				response,
+				nil,
+			),
+		); err != nil {
+			return nil, fmt.Errorf("failed to add job: %w", err)
+		}
 		if err := tx.Commit(); err != nil {
 			return nil, err
 		}
@@ -2048,15 +2126,8 @@ func (h *jobsQueryHandler) Handle(ctx context.Context, r *jobsQueryRequest) (*in
 			}
 		}
 	}
-	jobID := r.queryRequest.RequestId
-	if jobID == "" {
-		jobID = randomID() // generate job id
-	}
 	response.Rows = internaltypes.Format(response.Schema, response.Rows, r.useInt64Timestamp)
-	response.JobReference = &bigqueryv2.JobReference{
-		ProjectId: r.project.ID,
-		JobId:     jobID,
-	}
+	response.JobReference = job.JobReference
 	return response, nil
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -4174,6 +4175,102 @@ WHERE persona_id IN UNNEST(@ids)
 			t.Errorf("null scalar: got is_null=%v, want true", row[0])
 		}
 	})
+}
+
+// TestJobsQueryRegistersJob pins the contract that the synchronous
+// `jobs.query` endpoint records the job in the metadata store before
+// returning. Without that, the JobReference returned to the client points
+// at a job ID that `jobs.get` cannot find, and clients that look up the
+// source job after iterating (Go's `RowIterator.SourceJob().Status(ctx)`,
+// or the Java/Node/Python equivalents that poll the job for status) get
+// a 404 — which most clients then re-poll forever, surfacing as a hang.
+//
+// The Go BigQuery client's `Query.Read(ctx)` routes through `jobs.query`
+// when the query fits in a single response, so it is the natural shape
+// for the regression: `iter.SourceJob().Status(ctx)` must succeed and
+// see State=DONE.
+func TestJobsQueryRegistersJob(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "dataset_jq"
+	)
+	ctx := context.Background()
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(types.NewProject(
+		projectID,
+		types.NewDataset(datasetID,
+			types.NewTable("t",
+				[]*types.Column{types.NewColumn("id", types.INT64)},
+				types.Data{
+					{"id": int64(1)},
+					{"id": int64(2)},
+				},
+			),
+		),
+	))); err != nil {
+		t.Fatal(err)
+	}
+
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Close()
+	}()
+
+	client, err := bigquery.NewClient(ctx, projectID,
+		option.WithEndpoint(testServer.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// q.Read takes the jobs.query short path (no separate jobs.insert
+	// + poll dance). The iterator carries the jobID returned in the
+	// QueryResponse so we can then look the job up by ID below.
+	iter, err := client.Query(fmt.Sprintf("SELECT id FROM %s.t ORDER BY id", datasetID)).Read(ctx)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	var rows []int64
+	for {
+		var row []bigquery.Value
+		if err := iter.Next(&row); err != nil {
+			if err == iterator.Done {
+				break
+			}
+			t.Fatalf("iter.Next: %v", err)
+		}
+		rows = append(rows, row[0].(int64))
+	}
+	if want := []int64{1, 2}; !reflect.DeepEqual(rows, want) {
+		t.Fatalf("rows = %v; want %v", rows, want)
+	}
+
+	// SourceJob() pulls the JobReference out of the QueryResponse;
+	// Status(ctx) then issues a `jobs.get` against that ID. Before
+	// the fix, the GET returned 404 because jobsQueryHandler.Handle
+	// never wrote the job into the metadata store — the synthetic
+	// reference advertised to the client did not exist.
+	srcJob := iter.SourceJob()
+	if srcJob == nil {
+		t.Fatal("iter.SourceJob() returned nil; jobs.query did not advertise a JobReference")
+	}
+	status, err := srcJob.Status(ctx)
+	if err != nil {
+		t.Fatalf("jobs.get on %s/%s failed: %v (jobs.query did not register the job in metadata)",
+			srcJob.ProjectID(), srcJob.ID(), err)
+	}
+	if status.State != bigquery.Done {
+		t.Errorf("status.State = %v; want %v", status.State, bigquery.Done)
+	}
+	if status.Err() != nil {
+		t.Errorf("status.Err = %v; want nil", status.Err())
+	}
 }
 
 // TestExportDataStatement is a regression test for


### PR DESCRIPTION
## Why

`jobsQueryHandler.Handle` returns a `jobReference.jobId` to the caller but never writes the job into the metadata store. Any client that then looks up the source job — Go's `RowIterator.SourceJob().Status(ctx)`, the Java / Node / Python equivalents that poll for status after a synchronous query, or `bq show -j <id>` — gets a 404 and (for clients that treat 404 as transient) re-polls it forever, surfacing as a hang.

This was the unrelated 404 path I called out while validating #476. The EXPORT DATA work didn't trigger it (that path goes through `jobs.insert` + `jobs.get`, which both call `AddJob`), but it's a real bug on its own.

## Fix

Mirror what `jobsInsertHandler.Handle` already does at the async insert path: synthesize the minimum `bigqueryv2.Job` the GET handler reads, call `r.project.AddJob(...)` inside the same transaction as the query, then commit. DryRun queries skip both the `AddJob` and the `Commit` so they stay side-effect-free.

```go
job := &bigqueryv2.Job{
    Kind: "bigquery#job",
    JobReference: &bigqueryv2.JobReference{ProjectId: r.project.ID, JobId: jobID, Location: r.queryRequest.Location},
    Configuration: &bigqueryv2.JobConfiguration{
        JobType: "QUERY",
        DryRun:  r.queryRequest.DryRun,
        Query:   &bigqueryv2.JobConfigurationQuery{Query: r.queryRequest.Query, QueryParameters: r.queryRequest.QueryParameters, Priority: "INTERACTIVE"},
    },
    Status:     &bigqueryv2.JobStatus{State: "DONE"},
    Statistics: &bigqueryv2.JobStatistics{ /* CreationTime/StartTime/EndTime + totalBytes mirror jobsInsertHandler */ },
    SelfLink:   fmt.Sprintf("http://%s/bigquery/v2/projects/%s/jobs/%s", r.server.httpServer.Addr, r.project.ID, jobID),
}
if !r.queryRequest.DryRun {
    if err := r.project.AddJob(ctx, tx.Tx(), metadata.NewJob(r.server.metaRepo, r.project.ID, jobID, job, response, nil)); err != nil { ... }
    if err := tx.Commit(); err != nil { ... }
    // syncCatalog on changes...
}
```

## Latent bug surfaced: RequestId-as-jobId collision

Wiring this up made `TestConcurrentQueries` start failing:

```
worker 4 query 0: googleapi: Error 400: failed to add job: job request-20260520-...-0001 is already created
```

Root cause: the emulator was using `queryRequest.RequestId` **as the jobID**. `requestId` is BigQuery's *idempotency* key (a retry of the same logical operation), not a per-job identifier — real BigQuery allocates `jobs.query` jobIDs server-side. The Go BigQuery client in particular instantiates a fresh `uid.NewSpace("request", nil)` *per call*, so its per-Space atomic counter always emits `-0001`; two concurrent calls within the same nanosecond therefore submit identical RequestIds and would collide on `AddJob` once we actually persisted jobs.

This commit also aligns the emulator with the API spec: every `jobs.query` request gets a fresh jobID via `randomID()`. A `TODO` is left in the comment for honoring `RequestId` as an idempotency cache key (returning the cached response when the same `RequestId` is seen again). The previous behaviour of "same RequestId = same jobID" was never real idempotency anyway — it just suppressed the visible collision because no AddJob happened.

## Regression coverage

`TestJobsQueryRegistersJob` exercises `client.Query(...).Read(ctx)` (the `jobs.query` path) and asserts that `iter.SourceJob().Status(ctx)` returns `State=DONE` without erroring — i.e. the GET against the advertised jobID succeeds. The test fails on main with `googleapi: Error 404` and passes on this branch.

`TestConcurrentQueries`, which was the canary for the RequestId-collision bug, was already in the suite and is now also kept honest by the new persistence: any future regression that introduces jobID collisions will fail it.

## Test runs

- `go test -run '^TestJobsQueryRegistersJob$' ./server/...` — PASS (was 404 on main)
- `go test -run '^TestConcurrentQueries$' ./server/...` — PASS (16 workers × 5 queries, no collisions)
- `go test -run '^TestSimpleQuery$|^TestQueryWithNamedParams$|^TestQueryWithNullParams$|^TestInUnnestArrayParam$|^TestExportDataStatement$' ./server/...` — all PASS (no regression in adjacent tests)
- `go test ./server/...` — full server suite green (245s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
