### PR TITLE
Run the Docker image's wasm SQL engine in compiler mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,15 @@ COPY --from=builder /go/bin/bigquery-emulator /bin/bigquery-emulator
 
 WORKDIR /work
 
+# Run the embedded wasm SQL engine under the wazero compiler instead of
+# the interpreter default. For the emulator's workload (a long-lived
+# server answering many queries) the compiler is ~2x faster per query
+# and uses far less RSS; the only cost is a one-time AOT compile on the
+# first query. GOOGLESQLITE_WASM_CACHE_DIR amortises that compile across
+# container restarts. The cache cannot be pre-warmed at image-build time
+# because wazero's AOT output is architecture-specific and this image is
+# cross-compiled for multiple target arches.
+ENV GOOGLESQLITE_WASM_COMPILATION_MODE=compiler
+ENV GOOGLESQLITE_WASM_CACHE_DIR=/tmp/googlesqlite-wasm-cache
+
 ENTRYPOINT ["/bin/bigquery-emulator"]


### PR DESCRIPTION
## Why

The embedded GoogleSQL engine (googlesqlite, via wazero) runs in one of two modes — the wazero **interpreter** (its zero-setup default) or the wazero **AOT compiler**. The published `ghcr.io/goccy/bigquery-emulator` image has been inheriting the interpreter default, which is the slower mode and a significant factor in the slowness reports on #472 / #478.

## Measurement

Repeated `DROP / CREATE / INSERT / SELECT` workload, 15 iterations, interpreter vs `GOOGLESQLITE_WASM_COMPILATION_MODE=compiler` + cache dir:

| metric | interpreter | compiler |
| --- | --- | --- |
| per-query walltime | ~9.6 s/iter | ~4.9 s/iter (**~2× faster**) |
| hot RSS peak | ~976 MB | ~347 MB (**~⅓**) |

For the emulator's workload — a long-lived server answering many queries — the compiler is the better fit on both speed and memory.

## Change

```dockerfile
ENV GOOGLESQLITE_WASM_COMPILATION_MODE=compiler
ENV GOOGLESQLITE_WASM_CACHE_DIR=/tmp/googlesqlite-wasm-cache
```

- The only compiler-mode cost is a one-time AOT compile on the first query; `GOOGLESQLITE_WASM_CACHE_DIR` amortises it across container restarts.
- The cache **cannot** be pre-warmed at image-build time: wazero's AOT output is architecture-specific and this image is cross-compiled for multiple target arches. The first query in a fresh container therefore still pays the compile — a small, one-off cost for a server process.
- This sets the env vars in the **runtime image only**. Building from source or embedding the emulator as a library is unaffected and still defaults to the interpreter.

## Verification

Built the binary and ran it with these env vars:
- emulator started, `GOOGLESQLITE_WASM_CACHE_DIR` was created and populated (`wazero-v1.11.0-...`)
- `POST /queries` `SELECT 1 AS n` returned the correct result

Relates to #472, #478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
