### PR TITLE
Fix P1 bug triage regressions

### DIFF
--- a/internal/metadata/project.go
+++ b/internal/metadata/project.go
@@ -3,9 +3,12 @@ package metadata
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 )
+
+var ErrDuplicatedDataset = errors.New("dataset is already created")
 
 type Project struct {
 	ID         string
@@ -69,7 +72,7 @@ func (p *Project) AddDataset(ctx context.Context, tx *sql.Tx, dataset *Dataset) 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if _, exists := p.datasetMap[dataset.ID]; exists {
-		return fmt.Errorf("dataset %s is already created", dataset.ID)
+		return fmt.Errorf("dataset %s: %w", dataset.ID, ErrDuplicatedDataset)
 	}
 	if err := dataset.Insert(ctx, tx); err != nil {
 		return err

--- a/server/csv_autodetect.go
+++ b/server/csv_autodetect.go
@@ -93,15 +93,49 @@ func inferCSVColumnType(values []string) string {
 	}
 }
 
-// inferCSVSchema infers a table schema from CSV records, taking the first row
-// as the header (column names) and the remaining rows as sample data. It backs
-// the load job's autodetect option.
-func inferCSVSchema(records [][]string) (*bigqueryv2.TableSchema, error) {
-	if len(records) == 0 {
-		return nil, fmt.Errorf("cannot autodetect schema: the CSV has no rows")
+type csvRowWindow struct {
+	headerIndex int
+	dataStart   int
+	hasHeader   bool
+}
+
+func csvRowWindowFor(rowCount int, skipLeadingRows int64) (csvRowWindow, error) {
+	if rowCount == 0 {
+		return csvRowWindow{}, fmt.Errorf("the CSV has no rows")
 	}
-	header := records[0]
-	dataRows := records[1:]
+	if skipLeadingRows < 0 {
+		return csvRowWindow{}, fmt.Errorf("skipLeadingRows must be non-negative")
+	}
+	if skipLeadingRows > int64(rowCount) {
+		return csvRowWindow{dataStart: rowCount}, nil
+	}
+	if skipLeadingRows > 0 {
+		return csvRowWindow{
+			headerIndex: int(skipLeadingRows) - 1,
+			dataStart:   int(skipLeadingRows),
+			hasHeader:   true,
+		}, nil
+	}
+	return csvRowWindow{
+		headerIndex: 0,
+		dataStart:   0,
+		hasHeader:   true,
+	}, nil
+}
+
+// inferCSVSchema infers a table schema from CSV records. The header row is the
+// last skipped row when skipLeadingRows is set, otherwise it is the first row.
+// The remaining rows are used as sample data.
+func inferCSVSchema(records [][]string, skipLeadingRows int64) (*bigqueryv2.TableSchema, error) {
+	window, err := csvRowWindowFor(len(records), skipLeadingRows)
+	if err != nil {
+		return nil, fmt.Errorf("cannot autodetect schema: %w", err)
+	}
+	if !window.hasHeader {
+		return nil, fmt.Errorf("cannot autodetect schema: skipLeadingRows exceeds the CSV row count")
+	}
+	header := records[window.headerIndex]
+	dataRows := records[window.headerIndex+1:]
 	fields := make([]*bigqueryv2.TableFieldSchema, len(header))
 	for i, name := range header {
 		column := make([]string, 0, len(dataRows))

--- a/server/handler.go
+++ b/server/handler.go
@@ -444,6 +444,95 @@ func (h *uploadContentHandler) normalizeColumnNameForJSONData(columnMap map[stri
 	}
 }
 
+func newLoadCSVReader(reader io.Reader, fieldDelimiter string) (*csv.Reader, error) {
+	csvReader := csv.NewReader(reader)
+	csvReader.FieldsPerRecord = -1
+	if fieldDelimiter == "" {
+		return csvReader, nil
+	}
+	delimiters := []rune(fieldDelimiter)
+	if len(delimiters) != 1 {
+		return nil, fmt.Errorf("fieldDelimiter must be a single character")
+	}
+	csvReader.Comma = delimiters[0]
+	return csvReader, nil
+}
+
+func schemaColumns(fields []*bigqueryv2.TableFieldSchema) []*types.Column {
+	columns := make([]*types.Column, 0, len(fields))
+	for _, field := range fields {
+		columns = append(columns, types.NewColumnWithSchema(field))
+	}
+	return columns
+}
+
+func columnsFromCSVHeader(header []string, columnToType map[string]types.Type) ([]*types.Column, bool) {
+	columns := make([]*types.Column, 0, len(header))
+	for _, col := range header {
+		columnType, exists := columnToType[col]
+		if !exists {
+			return nil, false
+		}
+		columns = append(columns, &types.Column{
+			Name: col,
+			Type: columnType,
+		})
+	}
+	return columns, true
+}
+
+func csvLoadColumnsAndRows(records [][]string, schemaFields []*bigqueryv2.TableFieldSchema, columnToType map[string]types.Type, skipLeadingRows int64) ([]*types.Column, [][]string, error) {
+	window, err := csvRowWindowFor(len(records), skipLeadingRows)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !window.hasHeader {
+		return schemaColumns(schemaFields), nil, nil
+	}
+
+	dataStart := window.dataStart
+	if window.headerIndex < len(records) {
+		if columns, ok := columnsFromCSVHeader(records[window.headerIndex], columnToType); ok {
+			if dataStart <= window.headerIndex {
+				dataStart = window.headerIndex + 1
+			}
+			return columns, records[dataStart:], nil
+		}
+	}
+	return schemaColumns(schemaFields), records[dataStart:], nil
+}
+
+func csvRowsToTableData(records [][]string, schemaFields []*bigqueryv2.TableFieldSchema, skipLeadingRows int64, allowJaggedRows bool) ([]*types.Column, types.Data, error) {
+	columnToType := map[string]types.Type{}
+	for _, field := range schemaFields {
+		columnToType[field.Name] = types.Type(field.Type)
+	}
+	columns, dataRows, err := csvLoadColumnsAndRows(records, schemaFields, columnToType, skipLeadingRows)
+	if err != nil {
+		return nil, nil, err
+	}
+	data := types.Data{}
+	for _, record := range dataRows {
+		rowData := map[string]interface{}{}
+		if len(record) > len(columns) || (!allowJaggedRows && len(record) != len(columns)) {
+			return nil, nil, fmt.Errorf("invalid column number: found broken row data: %v", record)
+		}
+		for i := 0; i < len(columns); i++ {
+			var colData string
+			if i < len(record) {
+				colData = record[i]
+			}
+			if colData == "" {
+				rowData[columns[i].Name] = nil
+			} else {
+				rowData[columns[i].Name] = colData
+			}
+		}
+		data = append(data, rowData)
+	}
+	return columns, data, nil
+}
+
 func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentRequest) error {
 	load := r.job.Content().Configuration.Load
 	tableRef := load.DestinationTable
@@ -462,14 +551,21 @@ func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentReque
 	// Read CSV content up front so an autodetect load can infer the schema
 	// before the destination table is created.
 	var csvRecords [][]string
+	var csvColumns []*types.Column
+	var csvData types.Data
+	var csvDataReady bool
 	if load.SourceFormat == "CSV" {
-		records, err := csv.NewReader(r.reader).ReadAll()
+		csvReader, err := newLoadCSVReader(r.reader, load.FieldDelimiter)
+		if err != nil {
+			return err
+		}
+		records, err := csvReader.ReadAll()
 		if err != nil {
 			return fmt.Errorf("failed to read csv: %w", err)
 		}
 		csvRecords = records
 		if !tableExisted && load.Schema == nil && load.Autodetect {
-			schema, err := inferCSVSchema(csvRecords)
+			schema, err := inferCSVSchema(csvRecords, load.SkipLeadingRows)
 			if err != nil {
 				return err
 			}
@@ -479,6 +575,14 @@ func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentReque
 	if table == nil {
 		if load.CreateDisposition == "CREATE_NEVER" {
 			return fmt.Errorf("`%s` is not found", tableRef.TableId)
+		}
+		if load.SourceFormat == "CSV" && load.Schema != nil {
+			var err error
+			csvColumns, csvData, err = csvRowsToTableData(csvRecords, load.Schema.Fields, load.SkipLeadingRows, load.AllowJaggedRows)
+			if err != nil {
+				return err
+			}
+			csvDataReady = true
 		}
 		if _, err := (&tablesInsertHandler{}).Handle(ctx, &tablesInsertRequest{
 			server:  r.server,
@@ -498,58 +602,21 @@ func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentReque
 	if err != nil {
 		return err
 	}
-	columnToType := map[string]types.Type{}
-	for _, field := range tableContent.Schema.Fields {
-		columnToType[field.Name] = types.Type(field.Type)
-	}
 
 	sourceFormat := load.SourceFormat
 	columns := []*types.Column{}
 	data := types.Data{}
 	switch sourceFormat {
 	case "CSV":
-		records := csvRecords
-		if len(records) == 0 {
-			return fmt.Errorf("failed to find csv header")
+		if csvDataReady {
+			columns = csvColumns
+			data = csvData
+			break
 		}
-		if len(records) == 1 {
-			return nil
-		}
-		header := records[0]
-		var ignoreHeader bool
-		for _, col := range header {
-			if _, exists := columnToType[col]; !exists {
-				ignoreHeader = true
-				break
-			}
-			columns = append(columns, &types.Column{
-				Name: col,
-				Type: columnToType[col],
-			})
-		}
-		if ignoreHeader {
-			columns = []*types.Column{}
-			for _, field := range tableContent.Schema.Fields {
-				columns = append(columns, &types.Column{
-					Name: field.Name,
-					Type: types.Type(field.Type),
-				})
-			}
-		}
-		for _, record := range records[1:] {
-			rowData := map[string]interface{}{}
-			if len(record) != len(columns) {
-				return fmt.Errorf("invalid column number: found broken row data: %v", record)
-			}
-			for i := 0; i < len(record); i++ {
-				colData := record[i]
-				if colData == "" {
-					rowData[columns[i].Name] = nil
-				} else {
-					rowData[columns[i].Name] = colData
-				}
-			}
-			data = append(data, rowData)
+		var err error
+		columns, data, err = csvRowsToTableData(csvRecords, tableContent.Schema.Fields, load.SkipLeadingRows, load.AllowJaggedRows)
+		if err != nil {
+			return err
 		}
 	case "PARQUET":
 		b, err := io.ReadAll(r.reader)
@@ -559,12 +626,7 @@ func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentReque
 		reader := parquet.NewReader(bytes.NewReader(b))
 		defer reader.Close()
 
-		for _, f := range load.Schema.Fields {
-			columns = append(columns, &types.Column{
-				Name: f.Name,
-				Type: types.Type(f.Type),
-			})
-		}
+		columns = schemaColumns(load.Schema.Fields)
 
 		for i := 0; i < int(reader.NumRows()); i++ {
 			var rowData interface{}
@@ -576,12 +638,7 @@ func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentReque
 			data = append(data, rowData.(map[string]interface{}))
 		}
 	case "NEWLINE_DELIMITED_JSON":
-		for _, f := range tableContent.Schema.Fields {
-			columns = append(columns, &types.Column{
-				Name: f.Name,
-				Type: types.Type(f.Type),
-			})
-		}
+		columns = schemaColumns(tableContent.Schema.Fields)
 		columnMap := map[string]*types.Column{}
 		for _, col := range columns {
 			columnMap[col.Name] = col
@@ -858,6 +915,11 @@ func (h *datasetsInsertHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		dataset: &dataset,
 	})
 	if err != nil {
+		var serr *ServerError
+		if errors.As(err, &serr) {
+			errorResponse(ctx, w, serr)
+			return
+		}
 		errorResponse(ctx, w, errInternalError(err.Error()))
 		return
 	}
@@ -901,6 +963,9 @@ func (h *datasetsInsertHandler) Handle(ctx context.Context, r *datasetsInsertReq
 			nil,
 		),
 	); err != nil {
+		if errors.Is(err, metadata.ErrDuplicatedDataset) {
+			return nil, errDuplicate(err.Error())
+		}
 		return nil, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -1291,6 +1356,32 @@ func (h *jobsInsertHandler) tableDefFromQueryResponse(tableID string, response *
 	)
 }
 
+func (h *jobsInsertHandler) destinationProjectAndDataset(ctx context.Context, r *jobsInsertRequest, tableRef *bigqueryv2.TableReference) (*metadata.Project, *metadata.Dataset, error) {
+	projectID := tableRef.ProjectId
+	if projectID == "" {
+		projectID = r.project.ID
+		tableRef.ProjectId = projectID
+	}
+
+	project := r.project
+	if projectID != r.project.ID {
+		var err error
+		project, err = r.server.metaRepo.FindProject(ctx, projectID)
+		if err != nil {
+			return nil, nil, err
+		}
+		if project == nil {
+			return nil, nil, errNotFound(fmt.Sprintf("project %q is not found", projectID))
+		}
+	}
+
+	dataset := project.Dataset(tableRef.DatasetId)
+	if dataset == nil {
+		return nil, nil, errNotFound(fmt.Sprintf("dataset %q is not found in project %q", tableRef.DatasetId, projectID))
+	}
+	return project, dataset, nil
+}
+
 const (
 	gcsEmulatorHostEnvName = "STORAGE_EMULATOR_HOST"
 	gcsURIPrefix           = "gs://"
@@ -1648,7 +1739,8 @@ func (h *jobsInsertHandler) Handle(ctx context.Context, r *jobsInsertRequest) (*
 		}
 		return nil, fmt.Errorf("unspecified job configuration query")
 	}
-	conn, err := r.server.connMgr.Connection(ctx, r.project.ID, "")
+	queryProjectID, datasetID := queryProjectAndDataset(job.Configuration.Query.DefaultDataset, r.project.ID)
+	conn, err := r.server.connMgr.Connection(ctx, queryProjectID, datasetID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connection: %w", err)
 	}
@@ -1662,8 +1754,8 @@ func (h *jobsInsertHandler) Handle(ctx context.Context, r *jobsInsertRequest) (*
 	response, jobErr := r.server.contentRepo.Query(
 		ctx,
 		tx,
-		r.project.ID,
-		"",
+		queryProjectID,
+		datasetID,
 		job.Configuration.Query.Query,
 		job.Configuration.Query.QueryParameters,
 	)
@@ -1675,13 +1767,13 @@ func (h *jobsInsertHandler) Handle(ctx context.Context, r *jobsInsertRequest) (*
 		if hasDestinationTable {
 			// insert results to destination table
 			tableRef := job.Configuration.Query.DestinationTable
-			tableDef, err := h.tableDefFromQueryResponse(tableRef.TableId, response)
+			destinationProject, destinationDataset, err := h.destinationProjectAndDataset(ctx, r, tableRef)
 			if err != nil {
 				return nil, err
 			}
-			destinationDataset := r.project.Dataset(tableRef.DatasetId)
-			if destinationDataset == nil {
-				return nil, fmt.Errorf("failed to find destination dataset: %s", tableRef.DatasetId)
+			tableDef, err := h.tableDefFromQueryResponse(tableRef.TableId, response)
+			if err != nil {
+				return nil, err
 			}
 			destinationTable := destinationDataset.Table(tableRef.TableId)
 			destinationTableExists := destinationTable != nil
@@ -1698,16 +1790,18 @@ func (h *jobsInsertHandler) Handle(ctx context.Context, r *jobsInsertRequest) (*
 						tableRef.ProjectId, tableRef.DatasetId, tableRef.TableId,
 					))
 				}
-				_, err := createTableMetadata(ctx, tx, r.server, r.project, destinationDataset, tableDef.ToBigqueryV2(r.project.ID, tableRef.DatasetId))
+				table := tableDef.ToBigqueryV2(destinationProject.ID, tableRef.DatasetId)
+				_, err := createTableMetadata(ctx, tx, r.server, destinationProject, destinationDataset, table)
 				if err != nil {
 					return nil, fmt.Errorf("failed to create table: %w", err)
 				}
-				serverErr := r.server.contentRepo.CreateTable(ctx, tx, tableDef.ToBigqueryV2(r.project.ID, tableRef.DatasetId))
+				tx.SetProjectAndDataset(destinationProject.ID, tableRef.DatasetId)
+				serverErr := r.server.contentRepo.CreateTable(ctx, tx, tableDef.ToBigqueryV2(destinationProject.ID, tableRef.DatasetId))
 				if serverErr != nil {
 					return nil, fmt.Errorf("failed to create table: %w", serverErr)
 				}
 			}
-			if err := r.server.contentRepo.AddTableData(ctx, tx, tableRef.ProjectId, tableRef.DatasetId, tableDef); err != nil {
+			if err := r.server.contentRepo.AddTableData(ctx, tx, destinationProject.ID, tableRef.DatasetId, tableDef); err != nil {
 				return nil, fmt.Errorf("failed to add table data: %w", err)
 			}
 		} else if response != nil && response.Schema != nil && len(response.Schema.Fields) > 0 {
@@ -1781,6 +1875,18 @@ func (h *jobsInsertHandler) Handle(ctx context.Context, r *jobsInsertRequest) (*
 	}
 
 	return job, nil
+}
+
+func queryProjectAndDataset(defaultDataset *bigqueryv2.DatasetReference, fallbackProjectID string) (string, string) {
+	projectID := fallbackProjectID
+	var datasetID string
+	if defaultDataset != nil {
+		if defaultDataset.ProjectId != "" {
+			projectID = defaultDataset.ProjectId
+		}
+		datasetID = defaultDataset.DatasetId
+	}
+	return projectID, datasetID
 }
 
 func syncCatalog(ctx context.Context, server *Server, cat *googlesqlite.ChangedCatalog) error {
@@ -1917,6 +2023,7 @@ func (h *jobsInsertHandler) addQueryResultToDynamicDestinationTable(ctx context.
 	if err := r.server.metaRepo.AddTable(ctx, tx.Tx(), table); err != nil {
 		return nil, err
 	}
+	tx.SetProjectAndDataset(projectID, datasetID)
 	if err := r.server.contentRepo.CreateTable(ctx, tx, tableDef.ToBigqueryV2(projectID, datasetID)); err != nil {
 		return nil, err
 	}
@@ -2014,11 +2121,8 @@ type jobsQueryRequest struct {
 }
 
 func (h *jobsQueryHandler) Handle(ctx context.Context, r *jobsQueryRequest) (*internaltypes.QueryResponse, error) {
-	var datasetID string
-	if r.queryRequest.DefaultDataset != nil {
-		datasetID = r.queryRequest.DefaultDataset.DatasetId
-	}
-	conn, err := r.server.connMgr.Connection(ctx, r.project.ID, datasetID)
+	queryProjectID, datasetID := queryProjectAndDataset(r.queryRequest.DefaultDataset, r.project.ID)
+	conn, err := r.server.connMgr.Connection(ctx, queryProjectID, datasetID)
 	if err != nil {
 		return nil, err
 	}
@@ -2031,7 +2135,7 @@ func (h *jobsQueryHandler) Handle(ctx context.Context, r *jobsQueryRequest) (*in
 	response, queryErr := r.server.contentRepo.Query(
 		ctx,
 		tx,
-		r.project.ID,
+		queryProjectID,
 		datasetID,
 		r.queryRequest.Query,
 		r.queryRequest.QueryParameters,
@@ -2078,6 +2182,7 @@ func (h *jobsQueryHandler) Handle(ctx context.Context, r *jobsQueryRequest) (*in
 			DryRun:  r.queryRequest.DryRun,
 			Query: &bigqueryv2.JobConfigurationQuery{
 				Query:           r.queryRequest.Query,
+				DefaultDataset:  r.queryRequest.DefaultDataset,
 				QueryParameters: r.queryRequest.QueryParameters,
 				Priority:        "INTERACTIVE",
 			},

--- a/server/handler_internal_test.go
+++ b/server/handler_internal_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"testing"
+
+	bigqueryv2 "google.golang.org/api/bigquery/v2"
+)
+
+func TestQueryProjectAndDataset(t *testing.T) {
+	tests := []struct {
+		name              string
+		defaultDataset    *bigqueryv2.DatasetReference
+		fallbackProjectID string
+		wantProjectID     string
+		wantDatasetID     string
+	}{
+		{
+			name:              "nil default dataset",
+			fallbackProjectID: "request-project",
+			wantProjectID:     "request-project",
+		},
+		{
+			name: "default dataset without project uses fallback project",
+			defaultDataset: &bigqueryv2.DatasetReference{
+				DatasetId: "dataset",
+			},
+			fallbackProjectID: "request-project",
+			wantProjectID:     "request-project",
+			wantDatasetID:     "dataset",
+		},
+		{
+			name: "default dataset project overrides fallback project",
+			defaultDataset: &bigqueryv2.DatasetReference{
+				ProjectId: "default-project",
+				DatasetId: "dataset",
+			},
+			fallbackProjectID: "request-project",
+			wantProjectID:     "default-project",
+			wantDatasetID:     "dataset",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProjectID, gotDatasetID := queryProjectAndDataset(tt.defaultDataset, tt.fallbackProjectID)
+			if gotProjectID != tt.wantProjectID {
+				t.Fatalf("projectID = %q; want %q", gotProjectID, tt.wantProjectID)
+			}
+			if gotDatasetID != tt.wantDatasetID {
+				t.Fatalf("datasetID = %q; want %q", gotDatasetID, tt.wantDatasetID)
+			}
+		})
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1047,6 +1047,51 @@ func TestDuplicateTableWithSchema(t *testing.T) {
 	}
 }
 
+func TestDuplicateDatasetReturnsConflict(t *testing.T) {
+	const projectName = "test"
+	ctx := context.Background()
+
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(types.NewProject(projectName))); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+
+	client, err := bigquery.NewClient(
+		ctx,
+		projectName,
+		option.WithEndpoint(testServer.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	dataset := client.Dataset("dataset_dup")
+	if err := dataset.Create(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+	err = dataset.Create(ctx, nil)
+	if err == nil {
+		t.Fatal("creating a duplicate dataset should fail")
+	}
+	ge, ok := err.(*googleapi.Error)
+	if !ok {
+		t.Fatalf("expected *googleapi.Error, got %T: %v", err, err)
+	}
+	if ge.Code != http.StatusConflict {
+		t.Fatalf("duplicate dataset returned %d; want 409: %v", ge.Code, ge)
+	}
+}
+
 func TestDataFromStruct(t *testing.T) {
 	ctx := context.Background()
 
@@ -3600,6 +3645,148 @@ func TestUploadWithoutJobReference(t *testing.T) {
 	}
 }
 
+func TestUploadCSVHonorsFieldDelimiter(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "dataset1"
+	)
+	ctx := context.Background()
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(
+		types.NewProject(projectID, types.NewDataset(datasetID)),
+	)); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+
+	jobJSON := `{"configuration":{"load":{"sourceFormat":"CSV","autodetect":true,` +
+		`"fieldDelimiter":";","destinationTable":{"projectId":"test","datasetId":"dataset1","tableId":"semicolon_csv"}}}}`
+	contentType, body := multipartUpload(jobJSON, "name;age\r\nAlice;30\r\nBob;41")
+	code, resp := httpJSON(t, http.MethodPost,
+		testServer.URL+"/upload/bigquery/v2/projects/test/jobs?uploadType=multipart",
+		body, map[string]string{"Content-Type": contentType})
+	if code != http.StatusOK {
+		t.Fatalf("semicolon CSV upload: expected 200, got %d (%v)", code, resp)
+	}
+
+	code, resp = httpJSON(t, http.MethodPost,
+		testServer.URL+"/projects/test/queries",
+		`{"query":"SELECT name, age FROM dataset1.semicolon_csv ORDER BY age","useLegacySql":false}`, nil)
+	if code != http.StatusOK {
+		t.Fatalf("query semicolon CSV table: %d (%v)", code, resp)
+	}
+	rows := queryRows(t, resp)
+	want := [][]string{{"Alice", "30"}, {"Bob", "41"}}
+	if diff := cmp.Diff(want, rows); diff != "" {
+		t.Fatalf("semicolon CSV rows mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUploadCSVSkipLeadingRows(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "dataset1"
+	)
+	ctx := context.Background()
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(
+		types.NewProject(projectID, types.NewDataset(datasetID)),
+	)); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+
+	upload := func(t *testing.T, tableID, loadOptions, body string) [][]string {
+		t.Helper()
+		jobJSON := fmt.Sprintf(`{"configuration":{"load":{"sourceFormat":"CSV",%s`+
+			`"schema":{"fields":[{"name":"name","type":"STRING"},{"name":"age","type":"STRING"}]},`+
+			`"destinationTable":{"projectId":"%s","datasetId":"%s","tableId":"%s"}}}}`,
+			loadOptions, projectID, datasetID, tableID)
+		contentType, uploadBody := multipartUpload(jobJSON, body)
+		code, resp := httpJSON(t, http.MethodPost,
+			testServer.URL+"/upload/bigquery/v2/projects/test/jobs?uploadType=multipart",
+			uploadBody, map[string]string{"Content-Type": contentType})
+		if code != http.StatusOK {
+			t.Fatalf("CSV upload: expected 200, got %d (%v)", code, resp)
+		}
+
+		query := fmt.Sprintf(`{"query":"SELECT name, age FROM %s.%s ORDER BY name","useLegacySql":false}`, datasetID, tableID)
+		code, resp = httpJSON(t, http.MethodPost, testServer.URL+"/projects/test/queries", query, nil)
+		if code != http.StatusOK {
+			t.Fatalf("query CSV table: %d (%v)", code, resp)
+		}
+		return queryRows(t, resp)
+	}
+
+	t.Run("headerless CSV keeps first row", func(t *testing.T) {
+		rows := upload(t, "headerless_csv", "", "Alice,30\r\nBob,41")
+		want := [][]string{{"Alice", "30"}, {"Bob", "41"}}
+		if diff := cmp.Diff(want, rows); diff != "" {
+			t.Fatalf("headerless CSV rows mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("skipLeadingRows skips all leading rows", func(t *testing.T) {
+		rows := upload(t, "skip_leading_csv", `"skipLeadingRows":2,`, "ignored,ignored\r\nname,age\r\nAlice,30\r\nBob,41")
+		want := [][]string{{"Alice", "30"}, {"Bob", "41"}}
+		if diff := cmp.Diff(want, rows); diff != "" {
+			t.Fatalf("skipLeadingRows CSV rows mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("skipped rows may have different field counts", func(t *testing.T) {
+		rows := upload(t, "skip_variable_width_csv", `"skipLeadingRows":1,`, "description only\r\nAlice,30\r\nBob,41")
+		want := [][]string{{"Alice", "30"}, {"Bob", "41"}}
+		if diff := cmp.Diff(want, rows); diff != "" {
+			t.Fatalf("variable-width skipped CSV rows mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("allowJaggedRows pads trailing columns", func(t *testing.T) {
+		rows := upload(t, "allow_jagged_csv", `"allowJaggedRows":true,`, "Alice,30\r\nBob")
+		want := [][]string{{"Alice", "30"}, {"Bob", "<nil>"}}
+		if diff := cmp.Diff(want, rows); diff != "" {
+			t.Fatalf("allowJaggedRows CSV rows mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("invalid new-table CSV does not create destination table", func(t *testing.T) {
+		tableID := "invalid_new_csv"
+		jobJSON := fmt.Sprintf(`{"configuration":{"load":{"sourceFormat":"CSV",`+
+			`"schema":{"fields":[{"name":"name","type":"STRING"},{"name":"age","type":"STRING"}]},`+
+			`"destinationTable":{"projectId":"%s","datasetId":"%s","tableId":"%s"}}}}`,
+			projectID, datasetID, tableID)
+		contentType, uploadBody := multipartUpload(jobJSON, "Alice,30\r\nBadOnly")
+		code, resp := httpJSON(t, http.MethodPost,
+			testServer.URL+"/upload/bigquery/v2/projects/test/jobs?uploadType=multipart",
+			uploadBody, map[string]string{"Content-Type": contentType})
+		if code == http.StatusOK {
+			t.Fatalf("invalid CSV upload unexpectedly succeeded: %v", resp)
+		}
+
+		code, resp = httpJSON(t, http.MethodGet,
+			fmt.Sprintf("%s/projects/%s/datasets/%s/tables/%s", testServer.URL, projectID, datasetID, tableID),
+			"", nil)
+		if code != http.StatusNotFound {
+			t.Fatalf("destination table should not exist after failed upload, got %d (%v)", code, resp)
+		}
+	})
+}
+
 // TestUploadToMissingDataset covers #396: uploading to a non-existent dataset
 // must return a clean error instead of panicking the process.
 func TestUploadToMissingDataset(t *testing.T) {
@@ -4270,6 +4457,195 @@ func TestJobsQueryRegistersJob(t *testing.T) {
 	}
 	if status.Err() != nil {
 		t.Errorf("status.Err = %v; want nil", status.Err())
+	}
+}
+
+func TestJobsInsertQueryUsesDefaultDataset(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "dataset_jobs_insert_default"
+		jobID     = "job_default_dataset"
+	)
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(types.NewProject(
+		projectID,
+		types.NewDataset(datasetID,
+			types.NewTable("tableA",
+				[]*types.Column{types.NewColumn("name", types.STRING)},
+				types.Data{
+					{"name": "AAA"},
+					{"name": "BBB"},
+				},
+			),
+		),
+	))); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Close()
+	}()
+
+	body := fmt.Sprintf(`{
+		"jobReference":{"projectId":"%s","jobId":"%s"},
+		"configuration":{"query":{
+			"query":"SELECT name FROM tableA ORDER BY name",
+			"defaultDataset":{"projectId":"%s","datasetId":"%s"},
+			"useLegacySql":false
+		}}
+	}`, projectID, jobID, projectID, datasetID)
+	code, resp := httpJSON(t, http.MethodPost, testServer.URL+"/projects/test/jobs", body, nil)
+	if code != http.StatusOK {
+		t.Fatalf("jobs.insert: expected 200, got %d (%v)", code, resp)
+	}
+	if status, _ := resp["status"].(map[string]any); status["errorResult"] != nil {
+		t.Fatalf("jobs.insert query failed: %v", status["errorResult"])
+	}
+
+	code, resp = httpJSON(t, http.MethodGet, testServer.URL+"/projects/test/queries/"+jobID, "", nil)
+	if code != http.StatusOK {
+		t.Fatalf("getQueryResults: expected 200, got %d (%v)", code, resp)
+	}
+	rows := queryRows(t, resp)
+	want := [][]string{{"AAA"}, {"BBB"}}
+	if diff := cmp.Diff(want, rows); diff != "" {
+		t.Fatalf("jobs.insert default dataset rows mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestJobsInsertAnonymousDestinationWithCrossProjectDefaultDataset(t *testing.T) {
+	const (
+		projectID       = "test"
+		sourceProjectID = "source_project"
+		datasetID       = "dataset_jobs_insert_default_cross_project"
+		jobID           = "job_default_dataset_cross_project"
+	)
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(
+		types.NewProject(projectID),
+		types.NewProject(sourceProjectID,
+			types.NewDataset(datasetID,
+				types.NewTable("tableA",
+					[]*types.Column{types.NewColumn("name", types.STRING)},
+					types.Data{
+						{"name": "AAA"},
+						{"name": "BBB"},
+					},
+				),
+			),
+		),
+	)); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Close()
+	}()
+
+	body := fmt.Sprintf(`{
+		"jobReference":{"projectId":"%s","jobId":"%s"},
+		"configuration":{"query":{
+			"query":"SELECT name FROM tableA ORDER BY name",
+			"defaultDataset":{"projectId":"%s","datasetId":"%s"},
+			"useLegacySql":false
+		}}
+	}`, projectID, jobID, sourceProjectID, datasetID)
+	code, resp := httpJSON(t, http.MethodPost, testServer.URL+"/projects/test/jobs", body, nil)
+	if code != http.StatusOK {
+		t.Fatalf("jobs.insert: expected 200, got %d (%v)", code, resp)
+	}
+	if status, _ := resp["status"].(map[string]any); status["errorResult"] != nil {
+		t.Fatalf("jobs.insert query failed: %v", status["errorResult"])
+	}
+	configuration, _ := resp["configuration"].(map[string]any)
+	queryConfig, _ := configuration["query"].(map[string]any)
+	destinationTable, _ := queryConfig["destinationTable"].(map[string]any)
+	if destinationTable["projectId"] != projectID {
+		t.Fatalf("anonymous destination project = %v; want %s", destinationTable["projectId"], projectID)
+	}
+
+	code, resp = httpJSON(t, http.MethodGet, testServer.URL+"/projects/test/queries/"+jobID, "", nil)
+	if code != http.StatusOK {
+		t.Fatalf("getQueryResults: expected 200, got %d (%v)", code, resp)
+	}
+	rows := queryRows(t, resp)
+	want := [][]string{{"AAA"}, {"BBB"}}
+	if diff := cmp.Diff(want, rows); diff != "" {
+		t.Fatalf("jobs.insert default dataset rows mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestJobsInsertDestinationTableUsesDestinationProject(t *testing.T) {
+	const (
+		projectID     = "test"
+		destProjectID = "dest_project"
+		sourceDataset = "source_dataset"
+		destDataset   = "dest_dataset"
+		sourceTable   = "source_table"
+		destTable     = "copied_table"
+		jobID         = "job_destination_project"
+	)
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(
+		types.NewProject(projectID,
+			types.NewDataset(sourceDataset,
+				types.NewTable(sourceTable,
+					[]*types.Column{types.NewColumn("name", types.STRING)},
+					types.Data{
+						{"name": "AAA"},
+						{"name": "BBB"},
+					},
+				),
+			),
+		),
+		types.NewProject(destProjectID,
+			types.NewDataset(destDataset),
+		),
+	)); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Close()
+	}()
+
+	body := fmt.Sprintf(`{
+		"jobReference":{"projectId":"%s","jobId":"%s"},
+		"configuration":{"query":{
+			"query":"SELECT name FROM %s.%s ORDER BY name",
+			"destinationTable":{"projectId":"%s","datasetId":"%s","tableId":"%s"},
+			"useLegacySql":false
+		}}
+	}`, projectID, jobID, sourceDataset, sourceTable, destProjectID, destDataset, destTable)
+	code, resp := httpJSON(t, http.MethodPost, testServer.URL+"/projects/test/jobs", body, nil)
+	if code != http.StatusOK {
+		t.Fatalf("jobs.insert: expected 200, got %d (%v)", code, resp)
+	}
+	if status, _ := resp["status"].(map[string]any); status["errorResult"] != nil {
+		t.Fatalf("jobs.insert query failed: %v", status["errorResult"])
+	}
+
+	query := fmt.Sprintf(`{"query":"SELECT name FROM %s.%s ORDER BY name","useLegacySql":false}`, destDataset, destTable)
+	code, resp = httpJSON(t, http.MethodPost, testServer.URL+"/projects/"+destProjectID+"/queries", query, nil)
+	if code != http.StatusOK {
+		t.Fatalf("query destination table: expected 200, got %d (%v)", code, resp)
+	}
+	rows := queryRows(t, resp)
+	want := [][]string{{"AAA"}, {"BBB"}}
+	if diff := cmp.Diff(want, rows); diff != "" {
+		t.Fatalf("destination table rows mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/server/storage_handler.go
+++ b/server/storage_handler.go
@@ -383,6 +383,7 @@ type storageWriteServer struct {
 }
 
 type writeStreamStatus struct {
+	mu            sync.Mutex
 	streamType    storagepb.WriteStream_Type
 	stream        *storagepb.WriteStream
 	projectID     string
@@ -393,19 +394,8 @@ type writeStreamStatus struct {
 	finalized     bool
 }
 
-func (s *storageWriteServer) CreateWriteStream(ctx context.Context, req *storagepb.CreateWriteStreamRequest) (*storagepb.WriteStream, error) {
-	projectID, datasetID, tableID, err := getIDsFromPath(req.Parent)
-	if err != nil {
-		return nil, err
-	}
-	tableMetadata, err := getTableMetadata(ctx, s.server, projectID, datasetID, tableID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get table metadata: %w", err)
-	}
-	streamID := randomID()
-	streamName := fmt.Sprintf("%s/streams/%s", req.Parent, streamID)
+func newWriteStreamStatus(streamName string, streamType storagepb.WriteStream_Type, projectID, datasetID, tableID string, tableMetadata *bigqueryv2.Table) *writeStreamStatus {
 	createTime := timestamppb.New(time.Now())
-	streamType := req.GetWriteStream().GetType()
 	var commitTime *timestamppb.Timestamp
 	if streamType == storagepb.WriteStream_COMMITTED {
 		commitTime = createTime
@@ -419,8 +409,7 @@ func (s *storageWriteServer) CreateWriteStream(ctx context.Context, req *storage
 		TableSchema: schema,
 		WriteMode:   storagepb.WriteStream_INSERT,
 	}
-	s.mu.Lock()
-	s.streamMap[streamName] = &writeStreamStatus{
+	return &writeStreamStatus{
 		streamType:    streamType,
 		stream:        stream,
 		projectID:     projectID,
@@ -428,8 +417,44 @@ func (s *storageWriteServer) CreateWriteStream(ctx context.Context, req *storage
 		tableID:       tableID,
 		tableMetadata: tableMetadata,
 	}
+}
+
+func (s *writeStreamStatus) ensureAppendable() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.finalized {
+		return fmt.Errorf("stream is already finalized")
+	}
+	return nil
+}
+
+func (s *writeStreamStatus) appendBufferedRows(data types.Data) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.finalized {
+		return fmt.Errorf("stream is already finalized")
+	}
+	s.rows = append(s.rows, data...)
+	return nil
+}
+
+func (s *storageWriteServer) CreateWriteStream(ctx context.Context, req *storagepb.CreateWriteStreamRequest) (*storagepb.WriteStream, error) {
+	projectID, datasetID, tableID, err := getIDsFromPath(req.Parent)
+	if err != nil {
+		return nil, err
+	}
+	tableMetadata, err := getTableMetadata(ctx, s.server, projectID, datasetID, tableID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get table metadata: %w", err)
+	}
+	streamID := randomID()
+	streamName := fmt.Sprintf("%s/streams/%s", req.Parent, streamID)
+	streamType := req.GetWriteStream().GetType()
+	streamStatus := newWriteStreamStatus(streamName, streamType, projectID, datasetID, tableID, tableMetadata)
+	s.mu.Lock()
+	s.streamMap[streamName] = streamStatus
 	s.mu.Unlock()
-	return stream, nil
+	return streamStatus.stream, nil
 }
 
 func (s *storageWriteServer) AppendRows(stream storagepb.BigQueryWrite_AppendRowsServer) error {
@@ -444,7 +469,8 @@ func (s *storageWriteServer) AppendRows(stream storagepb.BigQueryWrite_AppendRow
 	if err != nil {
 		return err
 	}
-	if err := s.appendRows(req, msgDesc, stream); err != nil {
+	status, streamName, err := s.appendRows(req, msgDesc, stream, nil, "")
+	if err != nil {
 		return fmt.Errorf("failed to append rows: %w", err)
 	}
 	for {
@@ -455,7 +481,8 @@ func (s *storageWriteServer) AppendRows(stream storagepb.BigQueryWrite_AppendRow
 		if err != nil {
 			return err
 		}
-		if err := s.appendRows(req, msgDesc, stream); err != nil {
+		status, streamName, err = s.appendRows(req, msgDesc, stream, status, streamName)
+		if err != nil {
 			return fmt.Errorf("failed to append rows: %w", err)
 		}
 	}
@@ -477,25 +504,21 @@ func (s *storageWriteServer) getMessageDescriptor(req *storagepb.AppendRowsReque
 	return fd.Messages().ByName(protoreflect.Name(descProto.GetName())), nil
 }
 
-func (s *storageWriteServer) appendRows(req *storagepb.AppendRowsRequest, msgDesc protoreflect.MessageDescriptor, stream storagepb.BigQueryWrite_AppendRowsServer) error {
+func (s *storageWriteServer) appendRows(req *storagepb.AppendRowsRequest, msgDesc protoreflect.MessageDescriptor, stream storagepb.BigQueryWrite_AppendRowsServer, fallbackStatus *writeStreamStatus, fallbackStreamName string) (*writeStreamStatus, string, error) {
 	streamName := req.GetWriteStream()
-	s.mu.RLock()
 	var status *writeStreamStatus
 	if streamName == "" {
-		for _, s := range s.streamMap {
-			status = s
-			break
-		}
+		status = fallbackStatus
+		streamName = fallbackStreamName
 	} else {
-		s, exists := s.streamMap[streamName]
-		if !exists {
-			return fmt.Errorf("failed to get stream from %s", streamName)
+		var err error
+		status, streamName, err = s.getOrCreateWriteStreamStatus(stream.Context(), streamName)
+		if err != nil {
+			return nil, "", err
 		}
-		status = s
 	}
-	s.mu.RUnlock()
-	if status.finalized {
-		return fmt.Errorf("stream is already finalized")
+	if status == nil {
+		return nil, "", fmt.Errorf("write stream is not specified")
 	}
 	offset := int64(0)
 	if req.GetOffset() != nil {
@@ -505,36 +528,67 @@ func (s *storageWriteServer) appendRows(req *storagepb.AppendRowsRequest, msgDes
 	data, err := s.decodeData(msgDesc, rows)
 	if err != nil {
 		s.sendErrorMessage(stream, streamName, err)
-		return err
+		return nil, "", err
 	}
 	if status.streamType == storagepb.WriteStream_COMMITTED {
+		if err := status.ensureAppendable(); err != nil {
+			return nil, "", err
+		}
 		ctx := context.Background()
 		ctx = logger.WithLogger(ctx, s.server.logger)
 
 		conn, err := s.server.connMgr.Connection(ctx, status.projectID, status.datasetID)
 		if err != nil {
 			s.sendErrorMessage(stream, streamName, err)
-			return err
+			return nil, "", err
 		}
 		tx, err := conn.Begin(ctx)
 		if err != nil {
 			s.sendErrorMessage(stream, streamName, err)
-			return err
+			return nil, "", err
 		}
 		defer tx.RollbackIfNotCommitted()
 		if err := s.insertTableData(ctx, tx, status, data); err != nil {
 			s.sendErrorMessage(stream, streamName, err)
-			return err
+			return nil, "", err
 		}
 		if err := tx.Commit(); err != nil {
 			s.sendErrorMessage(stream, streamName, err)
-			return err
+			return nil, "", err
 		}
 	} else {
-		status.rows = append(status.rows, data...)
+		if err := status.appendBufferedRows(data); err != nil {
+			return nil, "", err
+		}
 	}
-	return s.sendResult(stream, streamName, offset+int64(len(rows)))
+	if err := s.sendResult(stream, streamName, offset+int64(len(rows))); err != nil {
+		return nil, "", err
+	}
+	return status, streamName, nil
 
+}
+
+func (s *storageWriteServer) lookupWriteStreamStatus(streamName string) (*writeStreamStatus, string, bool) {
+	canonicalName := canonicalWriteStreamName(streamName)
+	s.mu.RLock()
+	status, exists := s.streamMap[canonicalName]
+	s.mu.RUnlock()
+	return status, canonicalName, exists
+}
+
+func (s *storageWriteServer) getOrCreateWriteStreamStatus(ctx context.Context, streamName string) (*writeStreamStatus, string, error) {
+	status, canonicalName, exists := s.lookupWriteStreamStatus(streamName)
+	if exists {
+		return status, canonicalName, nil
+	}
+	if !isDefaultWriteStreamName(streamName) {
+		return nil, "", fmt.Errorf("failed to get stream from %s", streamName)
+	}
+	status, canonicalName, err := s.createDefaultStreamStatus(ctx, streamName)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get stream from %s", streamName)
+	}
+	return status, canonicalName, nil
 }
 
 func (s *storageWriteServer) sendResult(stream storagepb.BigQueryWrite_AppendRowsServer, streamName string, offset int64) error {
@@ -724,39 +778,31 @@ func (s *storageWriteServer) insertTableData(ctx context.Context, tx *connection
 }
 
 func (s *storageWriteServer) GetWriteStream(ctx context.Context, req *storagepb.GetWriteStreamRequest) (*storagepb.WriteStream, error) {
-	s.mu.RLock()
-	status, exists := s.streamMap[req.Name]
-	s.mu.RUnlock()
-	if !exists {
-		stream, err := s.createDefaultStream(ctx, req)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find stream from %s", req.Name)
-		}
-		return stream, err
+	status, _, err := s.getOrCreateWriteStreamStatus(ctx, req.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find stream from %s", req.Name)
 	}
 	return status.stream, nil
 }
 
 func (s *storageWriteServer) FinalizeWriteStream(ctx context.Context, req *storagepb.FinalizeWriteStreamRequest) (*storagepb.FinalizeWriteStreamResponse, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	status, exists := s.streamMap[req.GetName()]
+	status, _, exists := s.lookupWriteStreamStatus(req.GetName())
 	if !exists {
 		return nil, fmt.Errorf("failed to get stream from %s", req.GetName())
 	}
+	status.mu.Lock()
 	status.finalized = true
+	rowCount := int64(len(status.rows))
+	status.mu.Unlock()
 	return &storagepb.FinalizeWriteStreamResponse{
-		RowCount: int64(len(status.rows)),
+		RowCount: rowCount,
 	}, nil
 }
 
 func (s *storageWriteServer) BatchCommitWriteStreams(ctx context.Context, req *storagepb.BatchCommitWriteStreamsRequest) (*storagepb.BatchCommitWriteStreamsResponse, error) {
 	var streamErrors []*storagepb.StorageError
 	for _, streamName := range req.GetWriteStreams() {
-		s.mu.RLock()
-		status, exists := s.streamMap[streamName]
-		s.mu.RUnlock()
-
+		status, _, exists := s.lookupWriteStreamStatus(streamName)
 		if !exists {
 			streamErrors = append(streamErrors, &storagepb.StorageError{
 				Code:         storagepb.StorageError_STREAM_NOT_FOUND,
@@ -765,6 +811,9 @@ func (s *storageWriteServer) BatchCommitWriteStreams(ctx context.Context, req *s
 			})
 			continue
 		}
+		status.mu.Lock()
+		rows := append(types.Data(nil), status.rows...)
+		status.mu.Unlock()
 		conn, err := s.server.connMgr.Connection(ctx, status.projectID, status.datasetID)
 		if err != nil {
 			streamErrors = append(streamErrors, s.createUnspecifiedStorageError(streamName, err))
@@ -776,7 +825,7 @@ func (s *storageWriteServer) BatchCommitWriteStreams(ctx context.Context, req *s
 			continue
 		}
 		defer tx.RollbackIfNotCommitted()
-		if err := s.insertTableData(ctx, tx, status, status.rows); err != nil {
+		if err := s.insertTableData(ctx, tx, status, rows); err != nil {
 			streamErrors = append(streamErrors, s.createUnspecifiedStorageError(streamName, err))
 			continue
 		}
@@ -800,13 +849,21 @@ func (s *storageWriteServer) createUnspecifiedStorageError(streamName string, er
 
 func (s *storageWriteServer) FlushRows(ctx context.Context, req *storagepb.FlushRowsRequest) (*storagepb.FlushRowsResponse, error) {
 	streamName := req.GetWriteStream()
-	s.mu.RLock()
-	status, exists := s.streamMap[streamName]
-	s.mu.RUnlock()
+	status, _, exists := s.lookupWriteStreamStatus(streamName)
 	if !exists {
 		return nil, fmt.Errorf("failed to find stream from %s", streamName)
 	}
+	if req.GetOffset() == nil {
+		return nil, fmt.Errorf("offset is required")
+	}
 	offset := req.GetOffset().Value
+	status.mu.Lock()
+	if offset < 0 || offset >= int64(len(status.rows)) {
+		status.mu.Unlock()
+		return nil, fmt.Errorf("offset %d is out of range", offset)
+	}
+	rows := append(types.Data(nil), status.rows[:offset+1]...)
+	status.mu.Unlock()
 	conn, err := s.server.connMgr.Connection(ctx, status.projectID, status.datasetID)
 	if err != nil {
 		return nil, err
@@ -816,7 +873,7 @@ func (s *storageWriteServer) FlushRows(ctx context.Context, req *storagepb.Flush
 		return nil, err
 	}
 	defer tx.RollbackIfNotCommitted()
-	if err := s.insertTableData(ctx, tx, status, status.rows[:offset+1]); err != nil {
+	if err := s.insertTableData(ctx, tx, status, rows); err != nil {
 		return nil, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -827,56 +884,70 @@ func (s *storageWriteServer) FlushRows(ctx context.Context, req *storagepb.Flush
 	}, nil
 }
 
-/*
-*
-According to google documentation (https://pkg.go.dev/cloud.google.com/go/bigquery/storage/apiv1#BigQueryWriteClient.GetWriteStream)
-every table has a special stream named ‘_default’ to which data can be written. This stream doesn’t need to be created using CreateWriteStream
-
-Here we create the default stream and add it to map in case it not exists yet, the GetWriteStreamRequest given as second
-argument should have Name in this format: projects/<projectId>/datasets/<datasetId>/tables/<tableId>/streams/_default
-*/
+// According to google documentation every table has a special stream named
+// `_default` to which data can be written. This stream doesn't need to be
+// created using CreateWriteStream. Client libraries use both
+// projects/<projectId>/datasets/<datasetId>/tables/<tableId>/_default and
+// projects/<projectId>/datasets/<datasetId>/tables/<tableId>/streams/_default,
+// so accept both forms.
 func (s *storageWriteServer) createDefaultStream(ctx context.Context, req *storagepb.GetWriteStreamRequest) (*storagepb.WriteStream, error) {
-	streamId := req.Name
-	suffix := "_default"
-	streams := "/streams/"
-	if !strings.HasSuffix(streamId, suffix) {
-		return nil, fmt.Errorf("unexpected stream id: %s, expected '%s' suffix", streamId, suffix)
-	}
-	index := strings.LastIndex(streamId, streams)
-	if index == -1 {
-		return nil, fmt.Errorf("unexpected stream id: %s, expected containg '%s'", streamId, streams)
-	}
-	streamPart := streamId[:index]
-	writeStreamReq := &storagepb.CreateWriteStreamRequest{
-		Parent: streamPart,
-		WriteStream: &storagepb.WriteStream{
-			Type: storagepb.WriteStream_COMMITTED,
-		},
-	}
-	stream, err := s.CreateWriteStream(ctx, writeStreamReq)
+	status, _, err := s.createDefaultStreamStatus(ctx, req.Name)
 	if err != nil {
 		return nil, err
 	}
-	projectID, datasetID, tableID, err := getIDsFromPath(streamPart)
+	return status.stream, nil
+}
+
+func (s *storageWriteServer) createDefaultStreamStatus(ctx context.Context, streamName string) (*writeStreamStatus, string, error) {
+	tablePath, err := defaultWriteStreamTablePath(streamName)
 	if err != nil {
-		return nil, err
+		return nil, "", err
+	}
+	canonicalName := canonicalDefaultWriteStreamName(tablePath)
+	projectID, datasetID, tableID, err := getIDsFromPath(tablePath)
+	if err != nil {
+		return nil, "", err
 	}
 	tableMetadata, err := getTableMetadata(ctx, s.server, projectID, datasetID, tableID)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	streamStatus := &writeStreamStatus{
-		streamType:    storagepb.WriteStream_COMMITTED,
-		stream:        stream,
-		projectID:     projectID,
-		datasetID:     datasetID,
-		tableID:       tableID,
-		tableMetadata: tableMetadata,
-	}
+	streamStatus := newWriteStreamStatus(canonicalName, storagepb.WriteStream_COMMITTED, projectID, datasetID, tableID, tableMetadata)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.streamMap[streamId] = streamStatus
-	return stream, nil
+	if status, exists := s.streamMap[canonicalName]; exists {
+		return status, canonicalName, nil
+	}
+	s.streamMap[canonicalName] = streamStatus
+	return streamStatus, canonicalName, nil
+}
+
+func isDefaultWriteStreamName(name string) bool {
+	_, err := defaultWriteStreamTablePath(name)
+	return err == nil
+}
+
+func canonicalWriteStreamName(name string) string {
+	tablePath, err := defaultWriteStreamTablePath(name)
+	if err != nil {
+		return name
+	}
+	return canonicalDefaultWriteStreamName(tablePath)
+}
+
+func canonicalDefaultWriteStreamName(tablePath string) string {
+	return tablePath + "/_default"
+}
+
+func defaultWriteStreamTablePath(name string) (string, error) {
+	switch {
+	case strings.HasSuffix(name, "/streams/_default"):
+		return strings.TrimSuffix(name, "/streams/_default"), nil
+	case strings.HasSuffix(name, "/_default"):
+		return strings.TrimSuffix(name, "/_default"), nil
+	default:
+		return "", fmt.Errorf("unexpected default stream name: %s", name)
+	}
 }
 
 func getIDsFromPath(path string) (string, string, string, error) {
@@ -916,6 +987,9 @@ func getTableMetadata(ctx context.Context, server *Server, projectID, datasetID,
 	if err != nil {
 		return nil, err
 	}
+	if project == nil {
+		return nil, fmt.Errorf("project %s is not found", projectID)
+	}
 	dataset := project.Dataset(datasetID)
 	if dataset == nil {
 		return nil, fmt.Errorf("dataset %s is not found in project %s", datasetID, projectID)
@@ -924,12 +998,7 @@ func getTableMetadata(ctx context.Context, server *Server, projectID, datasetID,
 	if table == nil {
 		return nil, fmt.Errorf("table %s is not found in dataset %s", tableID, datasetID)
 	}
-	return new(tablesGetHandler).Handle(ctx, &tablesGetRequest{
-		server:  server,
-		project: project,
-		dataset: dataset,
-		table:   table,
-	})
+	return table.Content()
 }
 
 func registerStorageServer(grpcServer *grpc.Server, srv *Server) {

--- a/server/storage_internal_test.go
+++ b/server/storage_internal_test.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"context"
 	"testing"
 
+	storagepb "cloud.google.com/go/bigquery/storage/apiv1/storagepb"
+	"github.com/goccy/bigquery-emulator/types"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -55,4 +58,122 @@ func TestDecodeProtoWrapperValues(t *testing.T) {
 			t.Fatalf("decoded %T(%v); want []byte(\"ab\")", got, got)
 		}
 	})
+}
+
+func TestDefaultWriteStreamNameForms(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "dataset"
+		tableID   = "sample"
+	)
+	ctx := context.Background()
+	bqServer, err := New(TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(StructSource(types.NewProject(
+		projectID,
+		types.NewDataset(datasetID,
+			types.NewTable(tableID,
+				[]*types.Column{types.NewColumn("name", types.STRING)},
+				nil,
+			),
+		),
+	))); err != nil {
+		t.Fatal(err)
+	}
+	defer bqServer.Close()
+
+	writeServer := &storageWriteServer{
+		server:    bqServer,
+		streamMap: map[string]*writeStreamStatus{},
+	}
+	tablePath := "projects/test/datasets/dataset/tables/sample"
+	canonicalName := tablePath + "/_default"
+	var firstStatus *writeStreamStatus
+	for _, streamName := range []string{
+		tablePath + "/_default",
+		tablePath + "/streams/_default",
+	} {
+		t.Run(streamName, func(t *testing.T) {
+			stream, err := writeServer.createDefaultStream(ctx, &storagepb.GetWriteStreamRequest{Name: streamName})
+			if err != nil {
+				t.Fatalf("createDefaultStream: %v", err)
+			}
+			if stream.GetName() != canonicalName {
+				t.Fatalf("stream name = %q; want %q", stream.GetName(), canonicalName)
+			}
+			status, gotName, err := writeServer.getOrCreateWriteStreamStatus(ctx, streamName)
+			if err != nil {
+				t.Fatalf("getOrCreateWriteStreamStatus: %v", err)
+			}
+			if gotName != canonicalName {
+				t.Fatalf("resolved stream name = %q; want %q", gotName, canonicalName)
+			}
+			if firstStatus == nil {
+				firstStatus = status
+			} else if status != firstStatus {
+				t.Fatal("default stream name forms resolved to different statuses")
+			}
+			if status.streamType != storagepb.WriteStream_COMMITTED {
+				t.Fatalf("stream type = %v; want COMMITTED", status.streamType)
+			}
+			if status.projectID != projectID || status.datasetID != datasetID || status.tableID != tableID {
+				t.Fatalf("status table = %s.%s.%s; want %s.%s.%s",
+					status.projectID, status.datasetID, status.tableID,
+					projectID, datasetID, tableID)
+			}
+		})
+	}
+	if got := len(writeServer.streamMap); got != 1 {
+		t.Fatalf("default stream map entries = %d; want 1", got)
+	}
+}
+
+func TestDefaultWriteStreamLazyResolverConsumers(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "dataset"
+		tableID   = "sample"
+	)
+	ctx := context.Background()
+	bqServer, err := New(TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(StructSource(types.NewProject(
+		projectID,
+		types.NewDataset(datasetID,
+			types.NewTable(tableID,
+				[]*types.Column{types.NewColumn("name", types.STRING)},
+				nil,
+			),
+		),
+	))); err != nil {
+		t.Fatal(err)
+	}
+	defer bqServer.Close()
+
+	writeServer := &storageWriteServer{
+		server:    bqServer,
+		streamMap: map[string]*writeStreamStatus{},
+	}
+	streamName := "projects/test/datasets/dataset/tables/sample/streams/_default"
+	if _, err := writeServer.FinalizeWriteStream(ctx, &storagepb.FinalizeWriteStreamRequest{Name: streamName}); err == nil {
+		t.Fatal("FinalizeWriteStream should not create a missing default stream")
+	}
+	if got := len(writeServer.streamMap); got != 0 {
+		t.Fatalf("default stream map entries after finalize = %d; want 0", got)
+	}
+
+	stream, err := writeServer.GetWriteStream(ctx, &storagepb.GetWriteStreamRequest{Name: streamName})
+	if err != nil {
+		t.Fatalf("GetWriteStream: %v", err)
+	}
+	if stream.GetName() != "projects/test/datasets/dataset/tables/sample/_default" {
+		t.Fatalf("stream name = %q; want canonical default stream", stream.GetName())
+	}
+	if got := len(writeServer.streamMap); got != 1 {
+		t.Fatalf("default stream map entries = %d; want 1", got)
+	}
 }


### PR DESCRIPTION
## Summary
- return a 409 duplicate error for duplicate dataset creation
- honor CSV load fieldDelimiter and jobs.insert defaultDataset
- accept both BigQuery Storage Write default stream name forms and keep subsequent AppendRows requests bound to the same stream

Fixes #256
Fixes #329
Fixes #273
Fixes #342

## Tests
- go test ./server -run "TestDuplicateDatasetReturnsConflict|TestUploadCSVHonorsFieldDelimiter|TestJobsInsertQueryUsesDefaultDataset|TestDefaultWriteStreamNameForms" -count=1 -v
- go test ./server -run "TestStorageWrite|TestDefaultWriteStreamNameForms|TestDecodeProtoWrapperValues" -count=1 -v
- go test ./...
