### PR TITLE
fix(#481): ALTER TABLE ADD COLUMN — new columns invisible to subsequent queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ dist
 
 # Local output of the e2e conformance suite
 /test/e2e/.out/
+
+# Local reproduction scripts and logs
+/repro/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist
 
 # Local reproduction scripts and logs
 /repro/
+
+# Local development log (not for version control)
+devlog.md

--- a/internal/connection/manager.go
+++ b/internal/connection/manager.go
@@ -119,11 +119,10 @@ func (t *Tx) RawExec(ctx context.Context, query string, args ...interface{}) err
 		if !ok {
 			return fmt.Errorf("unexpected driver connection type %T", c)
 		}
-		f := reflect.ValueOf(gsqlConn).Elem().FieldByName("conn")
-		if !f.IsValid() {
-			return fmt.Errorf("googlesqlite.Conn has no 'conn' field")
+		innerConn, err := innerSQLConn(gsqlConn)
+		if err != nil {
+			return err
 		}
-		innerConn := *(**sql.Conn)(unsafe.Pointer(f.UnsafeAddr()))
 		_, execErr = innerConn.ExecContext(ctx, query, args...)
 		return nil
 	}); err != nil {
@@ -141,17 +140,32 @@ func (t *Tx) RawQueryRow(ctx context.Context, query string, args ...interface{})
 		if !ok {
 			return fmt.Errorf("unexpected driver connection type %T", c)
 		}
-		f := reflect.ValueOf(gsqlConn).Elem().FieldByName("conn")
-		if !f.IsValid() {
-			return fmt.Errorf("googlesqlite.Conn has no 'conn' field")
+		innerConn, err := innerSQLConn(gsqlConn)
+		if err != nil {
+			return err
 		}
-		innerConn := *(**sql.Conn)(unsafe.Pointer(f.UnsafeAddr()))
 		row = innerConn.QueryRowContext(ctx, query, args...)
 		return nil
 	}); err != nil {
 		return nil, err
 	}
 	return row, nil
+}
+
+// innerSQLConn extracts the unexported *sql.Conn from a *googlesqlite.Conn via
+// reflect. It validates the field name, kind, and exact type before the unsafe
+// pointer reinterpretation so a layout change in googlesqlite surfaces as a
+// clear error rather than a panic or memory corruption.
+func innerSQLConn(gsqlConn *googlesqlite.Conn) (*sql.Conn, error) {
+	f := reflect.ValueOf(gsqlConn).Elem().FieldByName("conn")
+	if !f.IsValid() {
+		return nil, fmt.Errorf("googlesqlite.Conn has no 'conn' field")
+	}
+	wantType := reflect.TypeOf((*sql.Conn)(nil))
+	if f.Kind() != reflect.Ptr || f.Type() != wantType {
+		return nil, fmt.Errorf("googlesqlite.Conn.conn has unexpected type %s (want %s)", f.Type(), wantType)
+	}
+	return *(**sql.Conn)(unsafe.Pointer(f.UnsafeAddr())), nil
 }
 
 // WithGSQLConn calls f with the underlying *googlesqlite.Conn. Use this to

--- a/internal/connection/manager.go
+++ b/internal/connection/manager.go
@@ -83,10 +83,10 @@ func (t *Tx) ContentRepoMode() error {
 		if !ok {
 			return fmt.Errorf("failed to get *googlesqlite.Conn from %T", c)
 		}
-		namePath := []string{}
-		if t.conn.ProjectID != "" {
-			namePath = append(namePath, t.conn.ProjectID)
+		if t.conn.ProjectID == "" {
+			return fmt.Errorf("invalid projectID. projectID is empty")
 		}
+		namePath := []string{t.conn.ProjectID}
 		if t.conn.DatasetID != "" {
 			namePath = append(namePath, t.conn.DatasetID)
 		}

--- a/internal/connection/manager.go
+++ b/internal/connection/manager.go
@@ -83,11 +83,15 @@ func (t *Tx) ContentRepoMode() error {
 		if !ok {
 			return fmt.Errorf("failed to get *googlesqlite.Conn from %T", c)
 		}
-		if t.conn.DatasetID == "" {
-			_ = gsqlConn.SetNamePath([]string{t.conn.ProjectID})
-		} else {
-			_ = gsqlConn.SetNamePath([]string{t.conn.ProjectID, t.conn.DatasetID})
+		namePath := []string{}
+		if t.conn.ProjectID != "" {
+			namePath = append(namePath, t.conn.ProjectID)
 		}
+		if t.conn.DatasetID != "" {
+			namePath = append(namePath, t.conn.DatasetID)
+		}
+		_ = gsqlConn.SetNamePath(namePath)
+
 		const maxNamePath = 3 // projectID and datasetID and tableID
 		gsqlConn.SetMaxNamePath(maxNamePath)
 		return nil

--- a/internal/connection/manager.go
+++ b/internal/connection/manager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"reflect"
+	"unsafe"
 
 	"github.com/goccy/googlesqlite"
 )
@@ -105,6 +107,64 @@ type Conn struct {
 	ProjectID string
 	DatasetID string
 	Conn      *sql.Conn
+}
+
+// RawExec executes a raw SQLite statement directly on the inner connection,
+// bypassing googlesqlite's ZetaSQL parser. Safe to call while a transaction
+// is active (after Begin, before Commit/Rollback).
+func (t *Tx) RawExec(ctx context.Context, query string, args ...interface{}) error {
+	var execErr error
+	if err := t.conn.Conn.Raw(func(c interface{}) error {
+		gsqlConn, ok := c.(*googlesqlite.Conn)
+		if !ok {
+			return fmt.Errorf("unexpected driver connection type %T", c)
+		}
+		f := reflect.ValueOf(gsqlConn).Elem().FieldByName("conn")
+		if !f.IsValid() {
+			return fmt.Errorf("googlesqlite.Conn has no 'conn' field")
+		}
+		innerConn := *(**sql.Conn)(unsafe.Pointer(f.UnsafeAddr()))
+		_, execErr = innerConn.ExecContext(ctx, query, args...)
+		return nil
+	}); err != nil {
+		return err
+	}
+	return execErr
+}
+
+// RawQueryRow executes a raw SQLite query, bypassing ZetaSQL, and returns
+// the single-row result. The caller must scan the row before the next call.
+func (t *Tx) RawQueryRow(ctx context.Context, query string, args ...interface{}) (*sql.Row, error) {
+	var row *sql.Row
+	if err := t.conn.Conn.Raw(func(c interface{}) error {
+		gsqlConn, ok := c.(*googlesqlite.Conn)
+		if !ok {
+			return fmt.Errorf("unexpected driver connection type %T", c)
+		}
+		f := reflect.ValueOf(gsqlConn).Elem().FieldByName("conn")
+		if !f.IsValid() {
+			return fmt.Errorf("googlesqlite.Conn has no 'conn' field")
+		}
+		innerConn := *(**sql.Conn)(unsafe.Pointer(f.UnsafeAddr()))
+		row = innerConn.QueryRowContext(ctx, query, args...)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return row, nil
+}
+
+// WithGSQLConn calls f with the underlying *googlesqlite.Conn. Use this to
+// manipulate googlesqlite internals (e.g. the in-memory ZetaSQL catalog)
+// from outside the package.
+func (t *Tx) WithGSQLConn(f func(*googlesqlite.Conn) error) error {
+	return t.conn.Conn.Raw(func(c interface{}) error {
+		gsqlConn, ok := c.(*googlesqlite.Conn)
+		if !ok {
+			return fmt.Errorf("unexpected driver connection type %T", c)
+		}
+		return f(gsqlConn)
+	})
 }
 
 func (c *Conn) Begin(ctx context.Context) (*Tx, error) {

--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -541,7 +541,7 @@ func (r *Repository) convertValueToCell(value interface{}, schema *bigqueryv2.Ta
 
 func (r *Repository) CreateOrReplaceTable(ctx context.Context, tx *connection.Tx, projectID, datasetID string, table *types.Table) error {
 	tx.SetProjectAndDataset(projectID, datasetID)
-	if err := tx.ContentRepoMode(); err != nil {
+	if err := tx.MetadataRepoMode(); err != nil {
 		return err
 	}
 	defer func() {
@@ -577,7 +577,7 @@ func (r *Repository) AddTableData(ctx context.Context, tx *connection.Tx, projec
 		return nil
 	}
 	tx.SetProjectAndDataset(projectID, datasetID)
-	if err := tx.ContentRepoMode(); err != nil {
+	if err := tx.MetadataRepoMode(); err != nil {
 		return err
 	}
 	defer func() {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -239,6 +239,9 @@ func formatCell(field *bigqueryv2.TableFieldSchema, cell *TableCell, useInt64Tim
 	if cell.V == nil {
 		return cell
 	}
+	if field == nil {
+		return cell
+	}
 
 	if field.Mode == "REPEATED" {
 		if cells, ok := cell.V.([]*TableCell); ok {
@@ -257,17 +260,21 @@ func formatCell(field *bigqueryv2.TableFieldSchema, cell *TableCell, useInt64Tim
 	}
 
 	if field.Type == "RECORD" {
-		if row, ok := cell.V.(TableRow); ok {
-			formattedF := make([]*TableCell, 0, len(row.F))
-			for i, c := range row.F {
-				var nestedField *bigqueryv2.TableFieldSchema
-				if i < len(field.Fields) {
-					nestedField = field.Fields[i]
-				}
-				formattedF = append(formattedF, formatCell(nestedField, c, useInt64Timestamp))
-			}
+		switch row := cell.V.(type) {
+		case TableRow:
+			formattedRow := formatRecordRow(field, &row, useInt64Timestamp)
 			return &TableCell{
-				V:     TableRow{F: formattedF},
+				V:     *formattedRow,
+				Bytes: cell.Bytes,
+				Name:  cell.Name,
+			}
+		case *TableRow:
+			if row == nil {
+				return cell
+			}
+			formattedRow := formatRecordRow(field, row, useInt64Timestamp)
+			return &TableCell{
+				V:     formattedRow,
 				Bytes: cell.Bytes,
 				Name:  cell.Name,
 			}
@@ -283,6 +290,18 @@ func formatCell(field *bigqueryv2.TableFieldSchema, cell *TableCell, useInt64Tim
 	}
 
 	return cell
+}
+
+func formatRecordRow(field *bigqueryv2.TableFieldSchema, row *TableRow, useInt64Timestamp bool) *TableRow {
+	formattedF := make([]*TableCell, 0, len(row.F))
+	for i, c := range row.F {
+		var nestedField *bigqueryv2.TableFieldSchema
+		if i < len(field.Fields) {
+			nestedField = field.Fields[i]
+		}
+		formattedF = append(formattedF, formatCell(nestedField, c, useInt64Timestamp))
+	}
+	return &TableRow{F: formattedF}
 }
 
 // formatTimestampCell renders one TIMESTAMP cell value. A non-string value or

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -226,19 +226,63 @@ func Format(schema *bigqueryv2.TableSchema, rows []*TableRow, useInt64Timestamp 
 	for _, row := range rows {
 		cells := make([]*TableCell, 0, len(row.F))
 		for colIdx, cell := range row.F {
-			if schema.Fields[colIdx].Type == "TIMESTAMP" && cell.V != nil {
-				cells = append(cells, &TableCell{
-					V: formatTimestampCell(cell.V, useInt64Timestamp),
-				})
-			} else {
-				cells = append(cells, cell)
-			}
+			cells = append(cells, formatCell(schema.Fields[colIdx], cell, useInt64Timestamp))
 		}
 		formattedRows = append(formattedRows, &TableRow{
 			F: cells,
 		})
 	}
 	return formattedRows
+}
+
+func formatCell(field *bigqueryv2.TableFieldSchema, cell *TableCell, useInt64Timestamp bool) *TableCell {
+	if cell.V == nil {
+		return cell
+	}
+
+	if field.Mode == "REPEATED" {
+		if cells, ok := cell.V.([]*TableCell); ok {
+			elemField := *field
+			elemField.Mode = "NULLABLE"
+			formattedCells := make([]*TableCell, 0, len(cells))
+			for _, c := range cells {
+				formattedCells = append(formattedCells, formatCell(&elemField, c, useInt64Timestamp))
+			}
+			return &TableCell{
+				V:     formattedCells,
+				Bytes: cell.Bytes,
+				Name:  cell.Name,
+			}
+		}
+	}
+
+	if field.Type == "RECORD" {
+		if row, ok := cell.V.(TableRow); ok {
+			formattedF := make([]*TableCell, 0, len(row.F))
+			for i, c := range row.F {
+				var nestedField *bigqueryv2.TableFieldSchema
+				if i < len(field.Fields) {
+					nestedField = field.Fields[i]
+				}
+				formattedF = append(formattedF, formatCell(nestedField, c, useInt64Timestamp))
+			}
+			return &TableCell{
+				V:     TableRow{F: formattedF},
+				Bytes: cell.Bytes,
+				Name:  cell.Name,
+			}
+		}
+	}
+
+	if field.Type == "TIMESTAMP" {
+		return &TableCell{
+			V:     formatTimestampCell(cell.V, useInt64Timestamp),
+			Bytes: cell.Bytes,
+			Name:  cell.Name,
+		}
+	}
+
+	return cell
 }
 
 // formatTimestampCell renders one TIMESTAMP cell value. A non-string value or

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1,0 +1,47 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	bigqueryv2 "google.golang.org/api/bigquery/v2"
+)
+
+func TestFormatCellHandlesNilField(t *testing.T) {
+	cell := &TableCell{V: "value"}
+	got := formatCell(nil, cell, true)
+	if got != cell {
+		t.Fatalf("formatCell(nil, cell) = %#v, want same cell pointer", got)
+	}
+}
+
+func TestFormatCellRecordPointerFormatsNestedTimestamp(t *testing.T) {
+	field := &bigqueryv2.TableFieldSchema{
+		Type: "RECORD",
+		Fields: []*bigqueryv2.TableFieldSchema{
+			{Type: "TIMESTAMP"},
+		},
+	}
+	row := &TableRow{
+		F: []*TableCell{{V: "2026-06-15T00:00:00Z"}},
+	}
+	cell := &TableCell{V: row}
+
+	got := formatCell(field, cell, true)
+	gotRow, ok := got.V.(*TableRow)
+	if !ok {
+		t.Fatalf("got.V type = %T, want *TableRow", got.V)
+	}
+	if len(gotRow.F) != 1 {
+		t.Fatalf("len(gotRow.F) = %d, want 1", len(gotRow.F))
+	}
+	tm, err := time.Parse(time.RFC3339, "2026-06-15T00:00:00Z")
+	if err != nil {
+		t.Fatalf("time.Parse failed: %v", err)
+	}
+	want := fmt.Sprint(tm.UnixMicro())
+	if gotRow.F[0].V != want {
+		t.Fatalf("nested timestamp = %v, want %v", gotRow.F[0].V, want)
+	}
+}

--- a/server/handler.go
+++ b/server/handler.go
@@ -18,8 +18,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"cloud.google.com/go/storage"
+	googlesql "github.com/goccy/go-googlesql"
 	"github.com/goccy/go-json"
 	"github.com/goccy/googlesqlite"
 	"go.uber.org/zap"
@@ -1751,14 +1753,22 @@ func (h *jobsInsertHandler) Handle(ctx context.Context, r *jobsInsertRequest) (*
 	defer tx.RollbackIfNotCommitted()
 	hasDestinationTable := job.Configuration.Query.DestinationTable != nil
 	startTime := time.Now()
-	response, jobErr := r.server.contentRepo.Query(
-		ctx,
-		tx,
-		queryProjectID,
-		datasetID,
-		job.Configuration.Query.Query,
-		job.Configuration.Query.QueryParameters,
-	)
+	queryText := job.Configuration.Query.Query
+	var alteredSpec *googlesqlite.TableSpec
+	var response *internaltypes.QueryResponse
+	var jobErr error
+	if isAlterTableQuery(queryText) {
+		alteredSpec, jobErr = executeAlterTableDDL(ctx, r.server, tx, queryProjectID, datasetID, queryText)
+	} else {
+		response, jobErr = r.server.contentRepo.Query(
+			ctx,
+			tx,
+			queryProjectID,
+			datasetID,
+			queryText,
+			job.Configuration.Query.QueryParameters,
+		)
+	}
 	endTime := time.Now()
 	if job.JobReference.JobId == "" {
 		job.JobReference.JobId = randomID() // generate job id
@@ -1872,6 +1882,11 @@ func (h *jobsInsertHandler) Handle(ctx context.Context, r *jobsInsertRequest) (*
 				return nil, err
 			}
 		}
+		if alteredSpec != nil {
+			if err := updateTableMetadata(ctx, r.server, alteredSpec); err != nil {
+				return nil, fmt.Errorf("failed to update table metadata after ALTER TABLE: %w", err)
+			}
+		}
 	}
 
 	return job, nil
@@ -1889,9 +1904,442 @@ func queryProjectAndDataset(defaultDataset *bigqueryv2.DatasetReference, fallbac
 	return projectID, datasetID
 }
 
+// isAlterTableQuery returns true when the SQL statement is an ALTER TABLE.
+func isAlterTableQuery(query string) bool {
+	q := strings.ToUpper(strings.TrimSpace(query))
+	return strings.HasPrefix(q, "ALTER") && strings.Contains(q, "TABLE")
+}
+
+// bqTypeKind maps a BigQuery type name (as returned by the ZetaSQL parser) to
+// the go-googlesql TypeKind integer stored in googlesqlite's catalog JSON.
+// This is the standard BigQuery type system — not application-specific logic.
+func bqTypeKind(typeName string) int {
+	switch strings.ToUpper(typeName) {
+	case "INT64", "INT", "INTEGER", "SMALLINT", "BIGINT", "TINYINT", "BYTEINT":
+		return int(googlesql.TypeKindTypeInt64)
+	case "INT32":
+		return int(googlesql.TypeKindTypeInt32)
+	case "FLOAT64", "FLOAT":
+		return int(googlesql.TypeKindTypeDouble)
+	case "FLOAT32":
+		return int(googlesql.TypeKindTypeFloat)
+	case "BOOL", "BOOLEAN":
+		return int(googlesql.TypeKindTypeBool)
+	case "STRING":
+		return int(googlesql.TypeKindTypeString)
+	case "BYTES":
+		return int(googlesql.TypeKindTypeBytes)
+	case "DATE":
+		return int(googlesql.TypeKindTypeDate)
+	case "DATETIME":
+		return int(googlesql.TypeKindTypeDatetime)
+	case "TIME":
+		return int(googlesql.TypeKindTypeTime)
+	case "TIMESTAMP":
+		return int(googlesql.TypeKindTypeTimestamp)
+	case "NUMERIC", "DECIMAL":
+		return int(googlesql.TypeKindTypeNumeric)
+	case "BIGNUMERIC", "BIGDECIMAL":
+		return int(googlesql.TypeKindTypeBignumeric)
+	case "JSON":
+		return int(googlesql.TypeKindTypeJson)
+	case "GEOGRAPHY":
+		return int(googlesql.TypeKindTypeGeography)
+	case "ARRAY":
+		return int(googlesql.TypeKindTypeArray)
+	case "STRUCT", "RECORD":
+		return int(googlesql.TypeKindTypeStruct)
+	default:
+		return int(googlesql.TypeKindTypeString)
+	}
+}
+
+// bqTypeToSQLite maps a BigQuery type name to the SQLite column affinity.
+// Mirrors googlesqlite's internal ColumnSpec.SQLiteSchema() mapping.
+func bqTypeToSQLite(typeName string) string {
+	switch strings.ToUpper(typeName) {
+	case "INT64", "INT", "INTEGER", "SMALLINT", "BIGINT", "TINYINT", "BYTEINT", "INT32":
+		return "INT"
+	case "BOOL", "BOOLEAN":
+		return "BOOLEAN"
+	case "FLOAT32":
+		return "FLOAT"
+	case "BYTES":
+		return "BLOB"
+	case "FLOAT64", "FLOAT", "DOUBLE":
+		return "DOUBLE"
+	case "JSON":
+		return "JSON"
+	default:
+		return "TEXT"
+	}
+}
+
+// parsedAlterAction describes a single action extracted from an ALTER TABLE AST.
+type parsedAlterAction struct {
+	kind    string // "ADD_COLUMN", "DROP_COLUMN", "RENAME_COLUMN"
+	colName string // column name (all actions)
+	colType string // BigQuery type string (ADD_COLUMN)
+	newName string // new column name (RENAME_COLUMN)
+}
+
+// parseAlterTable parses an ALTER TABLE query using the ZetaSQL AST and
+// returns the table path components and the list of actions.
+func parseAlterTable(query string) (tablePath []string, actions []parsedAlterAction, err error) {
+	opts, err := googlesql.NewParserOptions()
+	if err != nil {
+		return nil, nil, fmt.Errorf("alter table: parser options: %w", err)
+	}
+	out, err := googlesql.ParseStatement(query, opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("alter table: parse: %w", err)
+	}
+	stmt, err := out.Statement()
+	if err != nil {
+		return nil, nil, fmt.Errorf("alter table: get statement: %w", err)
+	}
+	altStmt, ok := stmt.(*googlesql.ASTAlterTableStatement)
+	if !ok {
+		return nil, nil, fmt.Errorf("alter table: expected ASTAlterTableStatement, got %T", stmt)
+	}
+	// Extract table path (e.g. ["dataset", "table"] or ["project","dataset","table"])
+	target, err := altStmt.GetDdlTarget()
+	if err != nil {
+		return nil, nil, fmt.Errorf("alter table: get DDL target: %w", err)
+	}
+	tablePath, err = target.ToIdentifierVector()
+	if err != nil {
+		return nil, nil, fmt.Errorf("alter table: table path: %w", err)
+	}
+	// Extract actions
+	actionList, err := altStmt.ActionList()
+	if err != nil {
+		return nil, nil, fmt.Errorf("alter table: action list: %w", err)
+	}
+	nChildren, err := actionList.NumChildren()
+	if err != nil {
+		return nil, nil, fmt.Errorf("alter table: num children: %w", err)
+	}
+	for i := int32(0); i < nChildren; i++ {
+		node, err := actionList.Actions(i)
+		if err != nil {
+			return nil, nil, fmt.Errorf("alter table: action %d: %w", i, err)
+		}
+		switch a := node.(type) {
+		case *googlesql.ASTAddColumnAction:
+			colDef, err := a.ColumnDefinition()
+			if err != nil {
+				return nil, nil, fmt.Errorf("alter table: add column definition: %w", err)
+			}
+			nameNode, err := colDef.Name()
+			if err != nil {
+				return nil, nil, fmt.Errorf("alter table: column name: %w", err)
+			}
+			colName, err := nameNode.GetAsString()
+			if err != nil {
+				return nil, nil, fmt.Errorf("alter table: column name string: %w", err)
+			}
+			schemaNode, err := colDef.Schema()
+			if err != nil {
+				return nil, nil, fmt.Errorf("alter table: column schema: %w", err)
+			}
+			simpleSchema, ok := schemaNode.(*googlesql.ASTSimpleColumnSchema)
+			if !ok {
+				return nil, nil, fmt.Errorf("alter table: unsupported column schema type %T", schemaNode)
+			}
+			typePath, err := simpleSchema.TypeName()
+			if err != nil {
+				return nil, nil, fmt.Errorf("alter table: type name: %w", err)
+			}
+			typeName, err := typePath.ToIdentifierPathString(0)
+			if err != nil {
+				return nil, nil, fmt.Errorf("alter table: type path string: %w", err)
+			}
+			actions = append(actions, parsedAlterAction{
+				kind:    "ADD_COLUMN",
+				colName: colName,
+				colType: typeName,
+			})
+		case *googlesql.ASTDropColumnAction:
+			nameNode, err := a.ColumnName()
+			if err != nil {
+				return nil, nil, fmt.Errorf("alter table: drop column name: %w", err)
+			}
+			colName, err := nameNode.GetAsString()
+			if err != nil {
+				return nil, nil, fmt.Errorf("alter table: drop column name string: %w", err)
+			}
+			actions = append(actions, parsedAlterAction{
+				kind:    "DROP_COLUMN",
+				colName: colName,
+			})
+		case *googlesql.ASTRenameColumnAction:
+			nameNode, err := a.ColumnName()
+			if err != nil {
+				return nil, nil, fmt.Errorf("alter table: rename column name: %w", err)
+			}
+			colName, err := nameNode.GetAsString()
+			if err != nil {
+				return nil, nil, fmt.Errorf("alter table: rename column name string: %w", err)
+			}
+			newNameNode, err := a.NewColumnName()
+			if err != nil {
+				return nil, nil, fmt.Errorf("alter table: rename new column name: %w", err)
+			}
+			newName, err := newNameNode.GetAsString()
+			if err != nil {
+				return nil, nil, fmt.Errorf("alter table: rename new column name string: %w", err)
+			}
+			actions = append(actions, parsedAlterAction{
+				kind:    "RENAME_COLUMN",
+				colName: colName,
+				newName: newName,
+			})
+		}
+	}
+	return tablePath, actions, nil
+}
+
+// updateZetaSQLCatalogForAlter updates the in-memory ZetaSQL SimpleCatalog
+// after an ALTER TABLE ADD COLUMN, bypassing googlesqlite's Sync path which
+// returns early for tables already present in c.tableMap and never propagates
+// schema changes to the WASM-side C++ SimpleCatalog.
+//
+// Strategy: reach through reflect+unsafe to get (*googlesqlite.Conn).catalog
+// (*internal.Catalog) → .catalog (*googlesql.SimpleCatalog), enumerate the
+// root-level tables, find the handle whose Name() equals the SQLite storage
+// name, and call AddColumn on it. Because googlesqlite aliases the SAME
+// *SimpleTable pointer under every lookup name in the catalog hierarchy, a
+// single AddColumn call makes the new column visible to the ZetaSQL analyzer
+// for all qualified references (e.g. "project.dataset.table" and "table").
+func updateZetaSQLCatalogForAlter(
+	gsqlConn *googlesqlite.Conn,
+	sqliteTableName string,
+	actions []parsedAlterAction,
+) error {
+	connVal := reflect.ValueOf(gsqlConn).Elem()
+
+	// (*googlesqlite.Conn).catalog → *internal.Catalog (unexported field)
+	catalogField := connVal.FieldByName("catalog")
+	if !catalogField.IsValid() {
+		return fmt.Errorf("googlesqlite.Conn has no 'catalog' field")
+	}
+	internalCatalogPtr := reflect.NewAt(catalogField.Type(), unsafe.Pointer(catalogField.UnsafeAddr())).Elem()
+
+	// (*internal.Catalog).catalog → *googlesql.SimpleCatalog (unexported field)
+	internalCatalogVal := internalCatalogPtr.Elem()
+	simpleCatalogField := internalCatalogVal.FieldByName("catalog")
+	if !simpleCatalogField.IsValid() {
+		return fmt.Errorf("internal.Catalog has no 'catalog' field")
+	}
+	simpleCatalogPtr := reflect.NewAt(simpleCatalogField.Type(), unsafe.Pointer(simpleCatalogField.UnsafeAddr())).Elem()
+	simpleCatalog, ok := simpleCatalogPtr.Interface().(*googlesql.SimpleCatalog)
+	if !ok {
+		return fmt.Errorf("expected *googlesql.SimpleCatalog, got %T", simpleCatalogPtr.Interface())
+	}
+
+	// The same *SimpleTable handle is aliased under multiple lookup names in
+	// the root catalog (e.g. "p.d.t", "d.t", "t"). Tables() returns them all;
+	// match on Name() which is always the storage name (strings.Join(path,"_")).
+	tables, err := simpleCatalog.Tables()
+	if err != nil {
+		return fmt.Errorf("failed to enumerate SimpleCatalog tables: %w", err)
+	}
+	var target *googlesql.SimpleTable
+	for _, node := range tables {
+		tbl, ok := node.(*googlesql.SimpleTable)
+		if !ok {
+			continue
+		}
+		name, err := tbl.Name()
+		if err != nil || name != sqliteTableName {
+			continue
+		}
+		target = tbl
+		break
+	}
+	if target == nil {
+		return fmt.Errorf("table %q not found in ZetaSQL SimpleCatalog", sqliteTableName)
+	}
+
+	tf, err := simpleCatalog.TypeFactory()
+	if err != nil {
+		return fmt.Errorf("failed to get TypeFactory from SimpleCatalog: %w", err)
+	}
+
+	for _, action := range actions {
+		if action.kind != "ADD_COLUMN" {
+			continue
+		}
+		colType, err := tf.MakeSimpleType(googlesql.TypeKind(bqTypeKind(action.colType)))
+		if err != nil {
+			return fmt.Errorf("failed to make ZetaSQL type for column %q: %w", action.colName, err)
+		}
+		newCol, err := googlesql.NewSimpleColumn(sqliteTableName, action.colName, colType, false, true)
+		if err != nil {
+			return fmt.Errorf("failed to create SimpleColumn %q: %w", action.colName, err)
+		}
+		if err := target.AddColumn(newCol); err != nil {
+			return fmt.Errorf("failed to add column %q to ZetaSQL table: %w", action.colName, err)
+		}
+	}
+	return nil
+}
+
+// executeAlterTableDDL handles ALTER TABLE by:
+//  1. Parsing the ZetaSQL AST to extract table path + actions (dynamic)
+//  2. Building the updated TableSpec from the current metadata
+//  3. Executing raw SQLite DDL on the inner connection (bypassing ZetaSQL)
+//  4. Upserting googlesqlite_catalog with the new spec JSON
+//
+// Returns the updated TableSpec, to be persisted to metadata after tx commit.
+func executeAlterTableDDL(
+	ctx context.Context,
+	server *Server,
+	tx *connection.Tx,
+	requestProjectID, requestDatasetID string,
+	query string,
+) (*googlesqlite.TableSpec, error) {
+	tablePath, actions, err := parseAlterTable(query)
+	if err != nil {
+		return nil, err
+	}
+	if len(actions) == 0 {
+		return nil, nil
+	}
+
+	// Resolve the full 3-part path (project, dataset, table).
+	var projectID, datasetID, tableID string
+	switch len(tablePath) {
+	case 1:
+		projectID = requestProjectID
+		datasetID = requestDatasetID
+		tableID = tablePath[0]
+	case 2:
+		projectID = requestProjectID
+		datasetID = tablePath[0]
+		tableID = tablePath[1]
+	case 3:
+		projectID = tablePath[0]
+		datasetID = tablePath[1]
+		tableID = tablePath[2]
+	default:
+		return nil, fmt.Errorf("unexpected ALTER TABLE path length: %v", tablePath)
+	}
+
+	// Load the current table metadata to get existing columns.
+	project, err := server.metaRepo.FindProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	dataset := project.Dataset(datasetID)
+	if dataset == nil {
+		return nil, fmt.Errorf("dataset %q not found", datasetID)
+	}
+	table := dataset.Table(tableID)
+	if table == nil {
+		return nil, fmt.Errorf("table %q not found", tableID)
+	}
+	tableMeta, err := table.Content()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read table content: %w", err)
+	}
+
+	// Build the current ColumnSpec slice from BigQuery schema.
+	namePath := []string{projectID, datasetID, tableID}
+	columns := make([]*googlesqlite.ColumnSpec, 0)
+	if tableMeta.Schema != nil {
+		for _, f := range tableMeta.Schema.Fields {
+			columns = append(columns, &googlesqlite.ColumnSpec{
+				Name: f.Name,
+				Type: &googlesqlite.Type{Kind: bqTypeKind(f.Type)},
+			})
+		}
+	}
+
+	// Apply each parsed action to derive the new column list.
+	sqliteTableName := strings.Join(namePath, "_")
+	for _, action := range actions {
+		switch action.kind {
+		case "ADD_COLUMN":
+			columns = append(columns, &googlesqlite.ColumnSpec{
+				Name: action.colName,
+				Type: &googlesqlite.Type{Kind: bqTypeKind(action.colType)},
+			})
+			ddl := fmt.Sprintf("ALTER TABLE `%s` ADD COLUMN `%s` %s",
+				sqliteTableName, action.colName, bqTypeToSQLite(action.colType))
+			if err := tx.RawExec(ctx, ddl); err != nil {
+				return nil, fmt.Errorf("failed to add column %q: %w", action.colName, err)
+			}
+		case "DROP_COLUMN":
+			newCols := columns[:0]
+			for _, c := range columns {
+				if !strings.EqualFold(c.Name, action.colName) {
+					newCols = append(newCols, c)
+				}
+			}
+			columns = newCols
+			ddl := fmt.Sprintf("ALTER TABLE `%s` DROP COLUMN `%s`",
+				sqliteTableName, action.colName)
+			if err := tx.RawExec(ctx, ddl); err != nil {
+				return nil, fmt.Errorf("failed to drop column %q: %w", action.colName, err)
+			}
+		case "RENAME_COLUMN":
+			for _, c := range columns {
+				if strings.EqualFold(c.Name, action.colName) {
+					c.Name = action.newName
+					break
+				}
+			}
+			ddl := fmt.Sprintf("ALTER TABLE `%s` RENAME COLUMN `%s` TO `%s`",
+				sqliteTableName, action.colName, action.newName)
+			if err := tx.RawExec(ctx, ddl); err != nil {
+				return nil, fmt.Errorf("failed to rename column %q: %w", action.colName, err)
+			}
+		}
+	}
+
+	// Construct the updated TableSpec.
+	newSpec := &googlesqlite.TableSpec{
+		NamePath: namePath,
+		Columns:  columns,
+	}
+
+	// Persist the updated spec to googlesqlite_catalog so the catalog is
+	// consistent when future queries are analyzed against this table.
+	specJSON, err := json.Marshal(newSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal updated table spec: %w", err)
+	}
+	upsertSQL := `
+INSERT INTO googlesqlite_catalog (name, kind, spec, updatedAt, createdAt)
+VALUES (?, 'table', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+ON CONFLICT(name) DO UPDATE SET spec = excluded.spec, updatedAt = CURRENT_TIMESTAMP`
+	if err := tx.RawExec(ctx, upsertSQL, sqliteTableName, string(specJSON)); err != nil {
+		return nil, fmt.Errorf("failed to update googlesqlite_catalog: %w", err)
+	}
+
+	// Update the in-memory ZetaSQL SimpleCatalog so subsequent query analysis
+	// sees the new columns without waiting for a Sync cycle. googlesqlite's
+	// addTableSpec takes the "existing table" branch for tables already in
+	// c.tableMap and returns early without touching the WASM-side catalog.
+	if err := tx.WithGSQLConn(func(gsqlConn *googlesqlite.Conn) error {
+		return updateZetaSQLCatalogForAlter(gsqlConn, sqliteTableName, actions)
+	}); err != nil {
+		return nil, fmt.Errorf("failed to update ZetaSQL in-memory catalog: %w", err)
+	}
+
+	return newSpec, nil
+}
+
 func syncCatalog(ctx context.Context, server *Server, cat *googlesqlite.ChangedCatalog) error {
 	for _, table := range cat.Table.Added {
 		if err := addTableMetadata(ctx, server, table); err != nil {
+			return err
+		}
+	}
+	for _, table := range cat.Table.Updated {
+		if err := updateTableMetadata(ctx, server, table); err != nil {
 			return err
 		}
 	}
@@ -1946,6 +2394,56 @@ func addTableMetadata(ctx context.Context, server *Server, spec *googlesqlite.Ta
 	}
 	if _, err := createTableMetadata(ctx, tx, server, project, dataset, table); err != nil {
 		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func updateTableMetadata(ctx context.Context, server *Server, spec *googlesqlite.TableSpec) error {
+	if len(spec.NamePath) != 3 {
+		return fmt.Errorf("unexpected table name path: %v", spec.NamePath)
+	}
+	projectID := spec.NamePath[0]
+	datasetID := spec.NamePath[1]
+	tableID := spec.NamePath[2]
+	project, err := server.metaRepo.FindProject(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	dataset := project.Dataset(datasetID)
+	if dataset == nil {
+		return fmt.Errorf("dataset %s is not found", datasetID)
+	}
+	table := dataset.Table(tableID)
+	if table == nil {
+		return fmt.Errorf("table %s is not found", tableID)
+	}
+	fields := make([]*bigqueryv2.TableFieldSchema, 0, len(spec.Columns))
+	for _, column := range spec.Columns {
+		fields = append(fields, types.TableFieldSchemaFromColumnType(column.Name, column.Type))
+	}
+	schema := &bigqueryv2.TableSchema{Fields: fields}
+	encoded, err := json.Marshal(schema)
+	if err != nil {
+		return fmt.Errorf("failed to encode updated schema: %w", err)
+	}
+	var schemaMap interface{}
+	if err := json.Unmarshal(encoded, &schemaMap); err != nil {
+		return fmt.Errorf("failed to decode updated schema: %w", err)
+	}
+	conn, err := server.connMgr.Connection(ctx, projectID, datasetID)
+	if err != nil {
+		return err
+	}
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.RollbackIfNotCommitted()
+	if err := table.Patch(ctx, tx.Tx(), map[string]interface{}{"schema": schemaMap}); err != nil {
+		return fmt.Errorf("failed to update table schema metadata: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return err
@@ -2132,14 +2630,21 @@ func (h *jobsQueryHandler) Handle(ctx context.Context, r *jobsQueryRequest) (*in
 	}
 	defer tx.RollbackIfNotCommitted()
 	startTime := time.Now()
-	response, queryErr := r.server.contentRepo.Query(
-		ctx,
-		tx,
-		queryProjectID,
-		datasetID,
-		r.queryRequest.Query,
-		r.queryRequest.QueryParameters,
-	)
+	var alteredSpec *googlesqlite.TableSpec
+	var response *internaltypes.QueryResponse
+	var queryErr error
+	if isAlterTableQuery(r.queryRequest.Query) {
+		alteredSpec, queryErr = executeAlterTableDDL(ctx, r.server, tx, queryProjectID, datasetID, r.queryRequest.Query)
+	} else {
+		response, queryErr = r.server.contentRepo.Query(
+			ctx,
+			tx,
+			queryProjectID,
+			datasetID,
+			r.queryRequest.Query,
+			r.queryRequest.QueryParameters,
+		)
+	}
 	if queryErr != nil {
 		return nil, queryErr
 	}
@@ -2225,11 +2730,19 @@ func (h *jobsQueryHandler) Handle(ctx context.Context, r *jobsQueryRequest) (*in
 		if err := tx.Commit(); err != nil {
 			return nil, err
 		}
-		if response.ChangedCatalog.Changed() {
+		if response != nil && response.ChangedCatalog.Changed() {
 			if err := syncCatalog(ctx, r.server, response.ChangedCatalog); err != nil {
 				return nil, err
 			}
 		}
+		if alteredSpec != nil {
+			if err := updateTableMetadata(ctx, r.server, alteredSpec); err != nil {
+				return nil, fmt.Errorf("failed to update table metadata after ALTER TABLE: %w", err)
+			}
+		}
+	}
+	if response == nil {
+		response = &internaltypes.QueryResponse{}
 	}
 	response.Rows = internaltypes.Format(response.Schema, response.Rows, r.useInt64Timestamp)
 	response.JobReference = job.JobReference

--- a/server/handler.go
+++ b/server/handler.go
@@ -3165,7 +3165,7 @@ func (h *tablesInsertHandler) Handle(ctx context.Context, r *tablesInsertRequest
 		r.table.TableReference.DatasetId = r.dataset.ID
 	}
 	if r.table.TableReference.TableId == "" {
-		r.table.TableReference.TableId = r.table.Id
+		r.table.TableReference.TableId = terminalTableID(r.table.Id)
 	}
 
 	conn, err := r.server.connMgr.Connection(ctx, r.project.ID, r.dataset.ID)
@@ -3206,6 +3206,20 @@ func (h *tablesInsertHandler) Handle(ctx context.Context, r *tablesInsertRequest
 		return nil, errInternalError(fmt.Errorf("failed to commit table: %w", err).Error())
 	}
 	return table, nil
+}
+
+func terminalTableID(id string) string {
+	if id == "" {
+		return ""
+	}
+	trimmed := id
+	if colon := strings.LastIndex(trimmed, ":"); colon >= 0 {
+		trimmed = trimmed[colon+1:]
+	}
+	if dot := strings.LastIndex(trimmed, "."); dot >= 0 {
+		trimmed = trimmed[dot+1:]
+	}
+	return trimmed
 }
 
 // handleExternalTable materializes an external table's source data into a

--- a/server/handler.go
+++ b/server/handler.go
@@ -1907,50 +1907,51 @@ func queryProjectAndDataset(defaultDataset *bigqueryv2.DatasetReference, fallbac
 // isAlterTableQuery returns true when the SQL statement is an ALTER TABLE.
 func isAlterTableQuery(query string) bool {
 	q := strings.ToUpper(strings.TrimSpace(query))
-	return strings.HasPrefix(q, "ALTER") && strings.Contains(q, "TABLE")
+	return strings.HasPrefix(q, "ALTER TABLE ")
 }
 
 // bqTypeKind maps a BigQuery type name (as returned by the ZetaSQL parser) to
 // the go-googlesql TypeKind integer stored in googlesqlite's catalog JSON.
-// This is the standard BigQuery type system — not application-specific logic.
-func bqTypeKind(typeName string) int {
+// Returns (kind, true) on success or (0, false) for unrecognised type names so
+// callers can surface a clear error instead of silently defaulting to STRING.
+func bqTypeKind(typeName string) (int, bool) {
 	switch strings.ToUpper(typeName) {
 	case "INT64", "INT", "INTEGER", "SMALLINT", "BIGINT", "TINYINT", "BYTEINT":
-		return int(googlesql.TypeKindTypeInt64)
+		return int(googlesql.TypeKindTypeInt64), true
 	case "INT32":
-		return int(googlesql.TypeKindTypeInt32)
+		return int(googlesql.TypeKindTypeInt32), true
 	case "FLOAT64", "FLOAT":
-		return int(googlesql.TypeKindTypeDouble)
+		return int(googlesql.TypeKindTypeDouble), true
 	case "FLOAT32":
-		return int(googlesql.TypeKindTypeFloat)
+		return int(googlesql.TypeKindTypeFloat), true
 	case "BOOL", "BOOLEAN":
-		return int(googlesql.TypeKindTypeBool)
+		return int(googlesql.TypeKindTypeBool), true
 	case "STRING":
-		return int(googlesql.TypeKindTypeString)
+		return int(googlesql.TypeKindTypeString), true
 	case "BYTES":
-		return int(googlesql.TypeKindTypeBytes)
+		return int(googlesql.TypeKindTypeBytes), true
 	case "DATE":
-		return int(googlesql.TypeKindTypeDate)
+		return int(googlesql.TypeKindTypeDate), true
 	case "DATETIME":
-		return int(googlesql.TypeKindTypeDatetime)
+		return int(googlesql.TypeKindTypeDatetime), true
 	case "TIME":
-		return int(googlesql.TypeKindTypeTime)
+		return int(googlesql.TypeKindTypeTime), true
 	case "TIMESTAMP":
-		return int(googlesql.TypeKindTypeTimestamp)
+		return int(googlesql.TypeKindTypeTimestamp), true
 	case "NUMERIC", "DECIMAL":
-		return int(googlesql.TypeKindTypeNumeric)
+		return int(googlesql.TypeKindTypeNumeric), true
 	case "BIGNUMERIC", "BIGDECIMAL":
-		return int(googlesql.TypeKindTypeBignumeric)
+		return int(googlesql.TypeKindTypeBignumeric), true
 	case "JSON":
-		return int(googlesql.TypeKindTypeJson)
+		return int(googlesql.TypeKindTypeJson), true
 	case "GEOGRAPHY":
-		return int(googlesql.TypeKindTypeGeography)
+		return int(googlesql.TypeKindTypeGeography), true
 	case "ARRAY":
-		return int(googlesql.TypeKindTypeArray)
+		return int(googlesql.TypeKindTypeArray), true
 	case "STRUCT", "RECORD":
-		return int(googlesql.TypeKindTypeStruct)
+		return int(googlesql.TypeKindTypeStruct), true
 	default:
-		return int(googlesql.TypeKindTypeString)
+		return 0, false
 	}
 }
 
@@ -2095,6 +2096,8 @@ func parseAlterTable(query string) (tablePath []string, actions []parsedAlterAct
 				colName: colName,
 				newName: newName,
 			})
+		default:
+			return nil, nil, fmt.Errorf("alter table: unsupported action type %T", node)
 		}
 	}
 	return tablePath, actions, nil
@@ -2171,7 +2174,11 @@ func updateZetaSQLCatalogForAlter(
 		if action.kind != "ADD_COLUMN" {
 			continue
 		}
-		colType, err := tf.MakeSimpleType(googlesql.TypeKind(bqTypeKind(action.colType)))
+		kind, ok := bqTypeKind(action.colType)
+		if !ok {
+			return fmt.Errorf("unsupported column type %q for ZetaSQL catalog", action.colType)
+		}
+		colType, err := tf.MakeSimpleType(googlesql.TypeKind(kind))
 		if err != nil {
 			return fmt.Errorf("failed to make ZetaSQL type for column %q: %w", action.colName, err)
 		}
@@ -2250,9 +2257,13 @@ func executeAlterTableDDL(
 	columns := make([]*googlesqlite.ColumnSpec, 0)
 	if tableMeta.Schema != nil {
 		for _, f := range tableMeta.Schema.Fields {
+			kind, ok := bqTypeKind(f.Type)
+			if !ok {
+				return nil, fmt.Errorf("unsupported column type %q in existing schema", f.Type)
+			}
 			columns = append(columns, &googlesqlite.ColumnSpec{
 				Name: f.Name,
-				Type: &googlesqlite.Type{Kind: bqTypeKind(f.Type)},
+				Type: &googlesqlite.Type{Kind: kind},
 			})
 		}
 	}
@@ -2262,9 +2273,13 @@ func executeAlterTableDDL(
 	for _, action := range actions {
 		switch action.kind {
 		case "ADD_COLUMN":
+			kind, ok := bqTypeKind(action.colType)
+			if !ok {
+				return nil, fmt.Errorf("unsupported column type %q", action.colType)
+			}
 			columns = append(columns, &googlesqlite.ColumnSpec{
 				Name: action.colName,
-				Type: &googlesqlite.Type{Kind: bqTypeKind(action.colType)},
+				Type: &googlesqlite.Type{Kind: kind},
 			})
 			ddl := fmt.Sprintf("ALTER TABLE `%s` ADD COLUMN `%s` %s",
 				sqliteTableName, action.colName, bqTypeToSQLite(action.colType))

--- a/server/handler.go
+++ b/server/handler.go
@@ -3097,6 +3097,15 @@ const (
 
 func createTableMetadata(ctx context.Context, tx *connection.Tx, server *Server, project *metadata.Project, dataset *metadata.Dataset, table *bigqueryv2.Table) (*bigqueryv2.Table, *ServerError) {
 	now := time.Now().Unix()
+	if table.TableReference == nil {
+		table.TableReference = &bigqueryv2.TableReference{}
+	}
+	if table.TableReference.ProjectId == "" {
+		table.TableReference.ProjectId = project.ID
+	}
+	if table.TableReference.DatasetId == "" {
+		table.TableReference.DatasetId = dataset.ID
+	}
 	table.Id = fmt.Sprintf("%s:%s.%s", project.ID, dataset.ID, table.TableReference.TableId)
 	table.CreationTime = now
 	table.LastModifiedTime = uint64(now)
@@ -3146,6 +3155,19 @@ func (h *tablesInsertHandler) Handle(ctx context.Context, r *tablesInsertRequest
 	if r.table.ExternalDataConfiguration != nil {
 		return h.handleExternalTable(ctx, r)
 	}
+	if r.table.TableReference == nil {
+		r.table.TableReference = &bigqueryv2.TableReference{}
+	}
+	if r.table.TableReference.ProjectId == "" {
+		r.table.TableReference.ProjectId = r.project.ID
+	}
+	if r.table.TableReference.DatasetId == "" {
+		r.table.TableReference.DatasetId = r.dataset.ID
+	}
+	if r.table.TableReference.TableId == "" {
+		r.table.TableReference.TableId = r.table.Id
+	}
+
 	conn, err := r.server.connMgr.Connection(ctx, r.project.ID, r.dataset.ID)
 	if err != nil {
 		return nil, errInternalError(err.Error())

--- a/server/handler_tableid_test.go
+++ b/server/handler_tableid_test.go
@@ -1,0 +1,25 @@
+package server
+
+import "testing"
+
+func TestTerminalTableID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "table only", in: "users", want: "users"},
+		{name: "dataset table", in: "sales.users", want: "users"},
+		{name: "project dataset table", in: "myproj:sales.users", want: "users"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := terminalTableID(tt.in)
+			if got != tt.want {
+				t.Fatalf("terminalTableID(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -941,6 +941,88 @@ func TestDDLCreateView(t *testing.T) {
 	}
 }
 
+func TestDDLAlterTable(t *testing.T) {
+	const (
+		projectName = "test"
+		datasetName = "dataset1"
+		tableName   = "customers"
+	)
+
+	ctx := context.Background()
+
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bqServer.Load(server.StructSource(types.NewProject(projectName, types.NewDataset(datasetName)))); err != nil {
+		t.Fatal(err)
+	}
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+
+	client, err := bigquery.NewClient(
+		ctx,
+		projectName,
+		option.WithEndpoint(testServer.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	runQuery := func(q string) {
+		t.Helper()
+		job, err := client.Query(q).Run(ctx)
+		if err != nil {
+			t.Fatalf("Query(%q) run: %v", q, err)
+		}
+		status, err := job.Wait(ctx)
+		if err != nil {
+			t.Fatalf("Query(%q) wait: %v", q, err)
+		}
+		if status.Err() != nil {
+			t.Fatalf("Query(%q) status: %v", q, status.Err())
+		}
+	}
+
+	runQuery(fmt.Sprintf("CREATE TABLE %s.%s (name STRING)", datasetName, tableName))
+	runQuery(fmt.Sprintf("ALTER TABLE %s.%s ADD COLUMN age INT64", datasetName, tableName))
+
+	// Schema must reflect the new column.
+	md, err := client.Dataset(datasetName).Table(tableName).Metadata(ctx)
+	if err != nil {
+		t.Fatalf("table metadata after ALTER TABLE: %v", err)
+	}
+	if len(md.Schema) != 2 {
+		t.Fatalf("schema has %d fields after ALTER TABLE, want 2: %v", len(md.Schema), md.Schema)
+	}
+	if md.Schema[1].Name != "age" {
+		t.Errorf("second field = %q, want %q", md.Schema[1].Name, "age")
+	}
+
+	// INSERT and SELECT must work with the new column.
+	runQuery(fmt.Sprintf("INSERT INTO %s.%s (name, age) VALUES ('Alice', 30)", datasetName, tableName))
+
+	it, err := client.Query(fmt.Sprintf("SELECT name, age FROM %s.%s", datasetName, tableName)).Read(ctx)
+	if err != nil {
+		t.Fatalf("SELECT after ALTER TABLE: %v", err)
+	}
+	var row struct {
+		Name string
+		Age  int64
+	}
+	if err := it.Next(&row); err != nil {
+		t.Fatalf("reading row: %v", err)
+	}
+	if row.Name != "Alice" || row.Age != 30 {
+		t.Errorf("got row {%q, %d}, want {Alice, 30}", row.Name, row.Age)
+	}
+}
+
 func TestDuplicateTable(t *testing.T) {
 	const (
 		projectName = "test"


### PR DESCRIPTION
> **Depends on PR #492.** This branch is based on the same commits as #492 (fixes for #470, #482, #483, #493). GitHub therefore shows those shared commits in this diff as well. The only change _unique_ to this PR is the final commit (`021f949`). Reviewers can focus exclusively on `server/handler.go` and `internal/connection/manager.go` for the ALTER TABLE logic, and `server/server_test.go` for `TestDDLAlterTable`. Once #492 is merged and this branch is rebased onto the updated main, the diff will show only the ALTER TABLE commit.

## Problem

`googlesqlite` treats `ALTER TABLE` as a no-op (`NoopStmtAction`): the underlying SQLite schema and the internal ZetaSQL catalog are never updated, so columns added via `ADD COLUMN` are invisible to subsequent `INSERT`/`SELECT` analysis — the query fails with _"Column X is not present in table"_.

Closes #481

## Approach

The fix intercepts `ALTER TABLE` in both `jobsInsertHandler` and `jobsQueryHandler` and applies three coordinated updates within the active transaction:

1. **Raw SQLite DDL** (`ADD COLUMN`, `DROP COLUMN`, `RENAME COLUMN`) executed via `reflect`+`unsafe` on the private inner `*sql.DB` inside `googlesqlite.Conn`.
2. **UPSERT of `googlesqlite_catalog`** with the new `TableSpec` JSON so the persisted catalog stays consistent.
3. **`AddColumn` on the WASM-side `SimpleTable`** inside the `SimpleCatalog`, making the column visible to the ZetaSQL analyzer immediately without reloading the catalog.

After commit, `updateTableMetadata` persists the updated BigQuery schema so the REST API returns the correct field list. All parsing is driven by the ZetaSQL AST — nothing is hardcoded.

## Trade-offs and risks

This fix accesses private fields of `googlesqlite.Conn` using `reflect`+`unsafe`. This is an acknowledged workaround for a gap in the public API of `googlesqlite`. The approach is self-contained — the unsafe pointer arithmetic is isolated to the ALTER TABLE handler and will need to be revisited if the internal structure of `googlesqlite.Conn` changes in a future version.

If the team prefers not to merge this until `googlesqlite` exposes an official hook, this PR can be deferred independently without blocking the other fixes in PR #492.

## Test plan

- `TestDDLAlterTable` (`server/server_test.go`) — covers `CREATE TABLE`, `ALTER TABLE ADD COLUMN`, metadata verification via the REST API, `INSERT` with the new column, and `SELECT` to confirm round-trip correctness.