### PR TITLE
fix(#399): ARRAY column causes panic in Storage Read API Arrow serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ dist
 
 # Local output of the e2e conformance suite
 /test/e2e/.out/
+
+# Local reproduction scripts and logs
+/repro/
+
+# Local development log
+devlog.md

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -195,9 +195,14 @@ func (c *TableCell) AppendValueToARROWBuilder(builder array.Builder) error {
 		if !ok {
 			return fmt.Errorf("failed to convert to list builder from %T", builder)
 		}
+		// Append(true) opens one list slot for this row. All element appends to
+		// ValueBuilder() that follow belong to this slot. Calling Append again
+		// (for the next row) implicitly closes the current slot. Placing this
+		// call inside the element loop is the root cause of issue #399: it opens
+		// N slots instead of 1, causing a row-count mismatch panic in NewRecord.
+		listBuilder.Append(true)
 		b := listBuilder.ValueBuilder()
 		for _, vv := range v {
-			listBuilder.Append(true)
 			if err := vv.AppendValueToARROWBuilder(b); err != nil {
 				return err
 			}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -195,11 +195,13 @@ func (c *TableCell) AppendValueToARROWBuilder(builder array.Builder) error {
 		if !ok {
 			return fmt.Errorf("failed to convert to list builder from %T", builder)
 		}
-		// Append(true) opens one list slot for this row. All element appends to
-		// ValueBuilder() that follow belong to this slot. Calling Append again
-		// (for the next row) implicitly closes the current slot. Placing this
-		// call inside the element loop is the root cause of issue #399: it opens
-		// N slots instead of 1, causing a row-count mismatch panic in NewRecord.
+		// BigQuery REPEATED fields are always non-null: a REPEATED column is
+		// either empty or populated, never null. Append(true) marks this list
+		// slot as valid (non-null) and opens it for elements. The slot is closed
+		// implicitly when Append is next called (for the following row). A nil
+		// []*TableCell is therefore treated identically to an empty slice.
+		// The original bug (issue #399) placed this call inside the element
+		// loop, opening N slots instead of 1 and causing a NewRecord panic.
 		listBuilder.Append(true)
 		b := listBuilder.ValueBuilder()
 		for _, vv := range v {

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1,0 +1,65 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+// TestAppendValueToARROWBuilder_List is a regression test for issue #399.
+// AppendValueToARROWBuilder was calling listBuilder.Append(true) inside the
+// per-element loop instead of once per row, producing N list slots instead of
+// 1 and causing a row-count mismatch panic in array.RecordBuilder.NewRecord.
+func TestAppendValueToARROWBuilder_List(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "items", Type: arrow.ListOf(arrow.PrimitiveTypes.Int64), Nullable: true},
+	}, nil)
+	rb := array.NewRecordBuilder(mem, schema)
+	defer rb.Release()
+
+	listBldr := rb.Field(0).(*array.ListBuilder)
+
+	rows := []struct {
+		cells  []*TableCell
+		wantLen int
+	}{
+		{
+			cells:   []*TableCell{{V: "1"}, {V: "2"}, {V: "3"}},
+			wantLen: 3,
+		},
+		{
+			cells:   []*TableCell{},
+			wantLen: 0,
+		},
+		{
+			cells:   []*TableCell{{V: "4"}},
+			wantLen: 1,
+		},
+	}
+
+	for _, row := range rows {
+		cell := &TableCell{V: row.cells}
+		if err := cell.AppendValueToARROWBuilder(listBldr); err != nil {
+			t.Fatalf("AppendValueToARROWBuilder: %v", err)
+		}
+	}
+
+	// NewRecord panics (row-count mismatch) when the bug is present.
+	rec := rb.NewRecord()
+	defer rec.Release()
+
+	if got := rec.NumRows(); got != int64(len(rows)) {
+		t.Fatalf("NumRows = %d, want %d", got, len(rows))
+	}
+
+	col := rec.Column(0).(*array.List)
+	for i, row := range rows {
+		start, end := col.ValueOffsets(i)
+		if got := int(end - start); got != row.wantLen {
+			t.Errorf("row %d: list length = %d, want %d", i, got, row.wantLen)
+		}
+	}
+}

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -23,7 +23,7 @@ func TestAppendValueToARROWBuilder_List(t *testing.T) {
 	listBldr := rb.Field(0).(*array.ListBuilder)
 
 	rows := []struct {
-		cells  []*TableCell
+		cells   []*TableCell
 		wantLen int
 	}{
 		{
@@ -37,6 +37,14 @@ func TestAppendValueToARROWBuilder_List(t *testing.T) {
 		{
 			cells:   []*TableCell{{V: "4"}},
 			wantLen: 1,
+		},
+		{
+			// A nil []*TableCell is a typed nil stored in the interface V field.
+			// BigQuery has no null-array concept for REPEATED columns, so nil
+			// must behave identically to an empty slice: a valid, non-null,
+			// zero-length list slot.
+			cells:   nil,
+			wantLen: 0,
 		},
 	}
 
@@ -60,6 +68,19 @@ func TestAppendValueToARROWBuilder_List(t *testing.T) {
 		start, end := col.ValueOffsets(i)
 		if got := int(end - start); got != row.wantLen {
 			t.Errorf("row %d: list length = %d, want %d", i, got, row.wantLen)
+		}
+	}
+
+	// Verify actual element values in the first row (cells "1","2","3" → 1,2,3).
+	valCol := col.ListValues().(*array.Int64)
+	start, end := col.ValueOffsets(0)
+	wantVals := []int64{1, 2, 3}
+	if got := int(end - start); got != len(wantVals) {
+		t.Fatalf("row 0 element count = %d, want %d", got, len(wantVals))
+	}
+	for i, wv := range wantVals {
+		if got := valCol.Value(int(start) + i); got != wv {
+			t.Errorf("row 0 element %d = %d, want %d", i, got, wv)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Reading a table that contains an `ARRAY` column via the Storage Read API (ARROW format) causes a server panic:

```
panic: arrow/array: field 2 has 6 rows. want=3
```

The row count mismatch is produced inside `array.RecordBuilder.NewRecord` when the Arrow record is assembled.

Closes #399

## Root cause

`AppendValueToARROWBuilder` in `internal/types/types.go` handles `[]*TableCell` (ARRAY columns) with this loop:

```go
for _, vv := range v {
    listBuilder.Append(true)   // ← inside the loop: one slot per element
    vv.AppendValueToARROWBuilder(b)
}
```

Arrow's `ListBuilder.Append(true)` opens **one list slot** (one logical row entry). Elements appended to `ValueBuilder()` after it fill that slot. Calling `Append` again (for the next row) implicitly closes the previous slot and opens a new one.

Placing the call inside the per-element loop creates N slots instead of 1 for an N-element array. A row with `[1,2,3]` produced 3 list-builder slots instead of 1, making the list-field's row count (6) diverge from the other fields' row count (3).

An empty array `[]` was also broken: the loop body never executed, so no slot was opened at all, dropping the row silently.

## Fix

Move `listBuilder.Append(true)` before the loop so exactly one slot is opened per row, regardless of the number of elements:

```go
listBuilder.Append(true)        // ← one slot per row
b := listBuilder.ValueBuilder()
for _, vv := range v {
    vv.AppendValueToARROWBuilder(b)
}
```

## Test

`TestAppendValueToARROWBuilder_List` in `internal/types/types_test.go` exercises three rows — a 3-element array, an empty array, and a 1-element array — and verifies:

1. `NewRecord` does not panic (the row-count mismatch is gone).
2. Each row's list length matches the inserted element count.
3. Element values are preserved correctly.